### PR TITLE
Feat: APR calculation for an arbitrary period

### DIFF
--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1137,9 +1137,9 @@ console.log(smaApr, 'sma apr by 7 days');
 
 ###### Input Parameters:
 
-- `props: { daysAgo, goBackFromBlock }`
-  - `daysAgo` (Type: number): The number of days ago from which to start searching for the first rebase event.
-  - `goBackFromBlock` (Type: number | undefined): Block number from which to start the search.
+- `props: { days, fromBlockNumber }`
+  - `days` (Type: number): The number of days ago from which to start searching for the first rebase event.
+  - `fromBlockNumber` (Type: number | undefined): Block number from which to start the search.
 
 ###### Output Parameters:
 
@@ -1178,11 +1178,13 @@ const lidoSDK = new LidoSDK({
 });
 
 const lastRebaseEvent = await lidoSDK.events.stethEvents.getLastRebaseEvent();
-const firstRebaseEvent = await lidoSDK.events.stethEvents.getFirstRebaseEvent();
+const firstRebaseEvent = await lidoSDK.events.stethEvents.getFirstRebaseEvent({
+  days: 3,
+});
 const lastRebaseEventsByCount =
-  await lidoSDK.events.stethEvents.getRebaseEvents({ count: 10 });
+  await lidoSDK.events.stethEvents.getRebaseEvents({ count: 7 });
 const lastRebaseEventsByDays =
-  await lidoSDK.events.stethEvents.getRebaseEventsByDays({ days: 10 });
+  await lidoSDK.events.stethEvents.getRebaseEventsByDays({ days: 7 });
 
 console.log(lastRebaseEvent, 'last rebase event');
 console.log(firstRebaseEvent, 'first rebase event');

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1085,6 +1085,27 @@ const wsteth = await lidoSDK.core.getContractAddress(
 
 ### APR
 
+#### Methods
+
+##### `getLastApr`
+
+###### Output Parameters:
+
+- Type: number
+
+##### `getSmaApr`
+
+###### Input Parameters:
+
+- `props: { days }`
+  - `days` (Type: number): The number of days back to return sma apr.
+
+###### Output Parameters:
+
+- Type: number
+
+#### Examples
+
 ```ts
 import { LidoSDK } from '@lidofinance/lido-ethereum-sdk';
 
@@ -1094,15 +1115,59 @@ const lidoSDK = new LidoSDK({
 });
 
 const lastApr = await lidoSDK.statistics.apr.getLastApr();
-const smaApr = await lidoSDK.statistics.apr.getSmaApr();
+const smaApr = await lidoSDK.statistics.apr.getSmaApr({ days: 7 });
 
 console.log(lastApr, 'last apr');
-console.log(smaApr, 'sma apr');
+console.log(smaApr, 'sma apr by 7 days');
 ```
 
 ## Lido events
 
 ### Rebase
+
+#### Methods
+
+##### `getLastRebaseEvent`
+
+###### Output Parameters:
+
+- Type: RebaseEvent
+
+##### `getFirstRebaseEvent`
+
+###### Input Parameters:
+
+- `props: { daysAgo, goBackFromBlock }`
+  - `daysAgo` (Type: number): The number of days ago from which to start searching for the first rebase event.
+  - `goBackFromBlock` (Type: number | undefined): Block number from which to start the search.
+
+###### Output Parameters:
+
+- Type: RebaseEvent
+
+##### `getRebaseEvents`
+
+###### Input Parameters:
+
+- `props: { count }`
+  - `count` (Type: number): The number of events to return.
+
+###### Output Parameters:
+
+- Type: Array of RebaseEvent objects
+
+##### `getRebaseEventsByDays`
+
+###### Input Parameters:
+
+- `props: { days }`
+  - `days` (Type: number): The number of days back to return rebase events.
+
+###### Output Parameters:
+
+- Type: Array of RebaseEvent objects
+
+#### Examples
 
 ```ts
 import { LidoSDK } from '@lidofinance/lido-ethereum-sdk';
@@ -1113,12 +1178,14 @@ const lidoSDK = new LidoSDK({
 });
 
 const lastRebaseEvent = await lidoSDK.events.stethEvents.getLastRebaseEvent();
+const firstRebaseEvent = await lidoSDK.events.stethEvents.getFirstRebaseEvent();
 const lastRebaseEventsByCount =
   await lidoSDK.events.stethEvents.getRebaseEvents({ count: 10 });
 const lastRebaseEventsByDays =
-  await lidoSDK.events.stethEvents.getRebaseEventByDays({ days: 10 });
+  await lidoSDK.events.stethEvents.getRebaseEventsByDays({ days: 10 });
 
 console.log(lastRebaseEvent, 'last rebase event');
+console.log(firstRebaseEvent, 'first rebase event');
 console.log(lastRebaseEventsByCount, 'last rebase events by count');
 console.log(lastRebaseEventsByDays, 'last rebase events by days');
 ```

--- a/packages/sdk/src/events/index.ts
+++ b/packages/sdk/src/events/index.ts
@@ -1,1 +1,2 @@
 export { LidoSDKEvents } from './events.js';
+export * from './types.js';

--- a/packages/sdk/src/events/stethEvents.ts
+++ b/packages/sdk/src/events/stethEvents.ts
@@ -59,15 +59,16 @@ export class LidoSDKStethEvents {
   @ErrorHandler()
   public async getLastRebaseEvent(): Promise<RebaseEvent | undefined> {
     const contract = await this.getContractStETH();
-    const lastBlock = await this.getLastBlock()
+    const lastBlock = await this.getLastBlock();
 
     for (let days = 1; days <= DAYS_LIMIT; days++) {
-      const fromBlock = lastBlock.number - BLOCKS_BY_DAY * BigInt(days)
+      const fromBlock = lastBlock.number - BLOCKS_BY_DAY * BigInt(days);
       const logs = await this.core.rpcProvider.getLogs({
         address: contract.address,
         event: StethEventsAbi[REBASE_EVENT_ABI_INDEX],
         fromBlock: fromBlock,
         toBlock: fromBlock + BLOCKS_BY_DAY,
+        strict: true,
       });
 
       if (logs.length > 0) return logs[logs.length - 1];
@@ -83,12 +84,13 @@ export class LidoSDKStethEvents {
     goBackFromBlock?: bigint;
   }): Promise<RebaseEvent | undefined> {
     const { daysAgo } = props;
-    const goBackFromBlock = props.goBackFromBlock ?? (await this.getLastBlock()).number
+    const goBackFromBlock =
+      props.goBackFromBlock ?? (await this.getLastBlock()).number;
 
     const contract = await this.getContractStETH();
 
     for (let days = 1; days <= DAYS_LIMIT; days++) {
-      const from = goBackFromBlock - BigInt(daysAgo + 1 - days) * BLOCKS_BY_DAY
+      const from = goBackFromBlock - BigInt(daysAgo + 1 - days) * BLOCKS_BY_DAY;
       const to = from + BLOCKS_BY_DAY;
 
       const logs = await this.core.rpcProvider.getLogs({
@@ -96,6 +98,7 @@ export class LidoSDKStethEvents {
         event: StethEventsAbi[REBASE_EVENT_ABI_INDEX],
         fromBlock: from,
         toBlock: to,
+        strict: true,
       });
 
       if (logs.length > 0) return logs[0];
@@ -124,6 +127,7 @@ export class LidoSDKStethEvents {
       event: StethEventsAbi[REBASE_EVENT_ABI_INDEX],
       fromBlock: block.number,
       toBlock: 'latest',
+      strict: true,
     });
 
     const logsByDays = logs.filter((log) => {
@@ -150,6 +154,7 @@ export class LidoSDKStethEvents {
       event: StethEventsAbi[8],
       fromBlock: block.number,
       toBlock: 'latest',
+      strict: true,
     });
 
     return logs.slice(logs.length - count);

--- a/packages/sdk/src/events/stethEvents.ts
+++ b/packages/sdk/src/events/stethEvents.ts
@@ -83,9 +83,6 @@ export class LidoSDKStethEvents {
     goBackFromBlock?: bigint;
   }): Promise<RebaseEvent | undefined> {
     const { daysAgo } = props;
-
-    invariant(daysAgo > 0, 'Days ago must be positive')
-
     const goBackFromBlock = props.goBackFromBlock ?? (await this.getLastBlock()).number
 
     const contract = await this.getContractStETH();

--- a/packages/sdk/src/events/stethEvents.ts
+++ b/packages/sdk/src/events/stethEvents.ts
@@ -79,15 +79,19 @@ export class LidoSDKStethEvents {
   @Logger('Events:')
   @ErrorHandler()
   public async getFirstRebaseEvent(props: {
-    fromBlock: bigint;
-    daysAgo: number
+    daysAgo: number;
+    goBackFromBlock?: bigint;
   }): Promise<RebaseEvent | undefined> {
-    const { fromBlock, daysAgo } = props;
+    const { daysAgo } = props;
+
+    invariant(daysAgo > 0, 'Days ago must be positive')
+
+    const goBackFromBlock = props.goBackFromBlock ?? (await this.getLastBlock()).number
 
     const contract = await this.getContractStETH();
 
     for (let days = 1; days <= DAYS_LIMIT; days++) {
-      const from = fromBlock + BigInt(days - 1 - daysAgo) * BLOCKS_BY_DAY
+      const from = goBackFromBlock - BigInt(daysAgo + 1 - days) * BLOCKS_BY_DAY
       const to = from + BLOCKS_BY_DAY;
 
       const logs = await this.core.rpcProvider.getLogs({

--- a/packages/sdk/src/events/stethEvents.ts
+++ b/packages/sdk/src/events/stethEvents.ts
@@ -61,8 +61,8 @@ export class LidoSDKStethEvents {
     const contract = await this.getContractStETH();
     const lastBlock = await this.getLastBlock();
 
-    for (let days = 1; days <= DAYS_LIMIT; days++) {
-      const fromBlock = lastBlock.number - BLOCKS_BY_DAY * BigInt(days);
+    for (let day = 1; day <= DAYS_LIMIT; day++) {
+      const fromBlock = lastBlock.number - BLOCKS_BY_DAY * BigInt(day);
       const logs = await this.core.rpcProvider.getLogs({
         address: contract.address,
         event: StethEventsAbi[REBASE_EVENT_ABI_INDEX],
@@ -80,17 +80,17 @@ export class LidoSDKStethEvents {
   @Logger('Events:')
   @ErrorHandler()
   public async getFirstRebaseEvent(props: {
-    daysAgo: number;
-    goBackFromBlock?: bigint;
+    days: number;
+    fromBlockNumber?: bigint;
   }): Promise<RebaseEvent | undefined> {
-    const { daysAgo } = props;
-    const goBackFromBlock =
-      props.goBackFromBlock ?? (await this.getLastBlock()).number;
+    const { days } = props;
+    const fromBlockNumber =
+      props.fromBlockNumber ?? (await this.getLastBlock()).number;
 
     const contract = await this.getContractStETH();
 
-    for (let days = 1; days <= DAYS_LIMIT; days++) {
-      const from = goBackFromBlock - BigInt(daysAgo + 1 - days) * BLOCKS_BY_DAY;
+    for (let day = 1; day <= DAYS_LIMIT; day++) {
+      const from = fromBlockNumber - BigInt(days + 1 - day) * BLOCKS_BY_DAY;
       const to = from + BLOCKS_BY_DAY;
 
       const logs = await this.core.rpcProvider.getLogs({

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -15,13 +15,13 @@ export type RebaseEvent = {
   transactionHash: string;
   transactionIndex: number;
   args: {
-    reportTimestamp?: bigint;
-    timeElapsed?: bigint;
-    preTotalShares?: bigint;
-    preTotalEther?: bigint;
-    postTotalShares?: bigint;
-    postTotalEther?: bigint;
-    sharesMintedAsFees?: bigint;
+    reportTimestamp: bigint;
+    timeElapsed: bigint;
+    preTotalShares: bigint;
+    preTotalEther: bigint;
+    postTotalShares: bigint;
+    postTotalEther: bigint;
+    sharesMintedAsFees: bigint;
   };
   eventName: 'TokenRebased';
 };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,3 +16,5 @@ export {
 } from './withdraw/index.js';
 export { LIDO_CONTRACT_NAMES } from './common/constants.js';
 export { type WrapProps } from './wrap/index.js';
+export { LidoSDKEvents, RebaseEvent } from './events/index.js';
+export { LidoSDKStatistics } from './statistics/index.js';

--- a/packages/sdk/src/statistics/apr.ts
+++ b/packages/sdk/src/statistics/apr.ts
@@ -40,8 +40,8 @@ export class LidoSDKApr {
     invariant(lastEvent, 'Last event is not defined');
 
     const firstEvent = await this.events.stethEvents.getFirstRebaseEvent({
-      daysAgo: days,
-      goBackFromBlock: lastEvent.blockNumber,
+      days,
+      fromBlockNumber: lastEvent.blockNumber,
     });
     invariant(firstEvent, 'First event is not defined');
 

--- a/packages/sdk/src/statistics/apr.ts
+++ b/packages/sdk/src/statistics/apr.ts
@@ -33,26 +33,21 @@ export class LidoSDKApr {
 
   @Logger('Statistic:')
   @ErrorHandler()
-  public async getSmaApr(props: {
-    days: number;
-  }): Promise<number> {
+  public async getSmaApr(props: { days: number }): Promise<number> {
     const { days } = props;
 
-    const lastEvent = await this.events.stethEvents.getLastRebaseEvent()
-    invariant(lastEvent, 'Last event is not defined')
+    const lastEvent = await this.events.stethEvents.getLastRebaseEvent();
+    invariant(lastEvent, 'Last event is not defined');
 
     const firstEvent = await this.events.stethEvents.getFirstRebaseEvent({
-      daysAgo: days, goBackFromBlock: lastEvent.blockNumber,
-    })
-    invariant(firstEvent, 'First event is not defined')
+      daysAgo: days,
+      goBackFromBlock: lastEvent.blockNumber,
+    });
+    invariant(firstEvent, 'First event is not defined');
 
-    invariant(firstEvent.args.timeElapsed, 'time elapsed is not defined')
-    invariant(lastEvent.args.reportTimestamp, 'Last event reportTimestamp is not defined')
-    invariant(firstEvent.args.reportTimestamp, 'First event reportTimestamp is not defined')
-
-    const timeElapsed = firstEvent.args.timeElapsed + (
-      lastEvent.args.reportTimestamp - firstEvent.args.reportTimestamp
-    );
+    const timeElapsed =
+      firstEvent.args.timeElapsed +
+      (lastEvent.args.reportTimestamp - firstEvent.args.reportTimestamp);
 
     const smaApr = this.calculateApr({
       preTotalEther: firstEvent.args.preTotalEther,
@@ -60,17 +55,17 @@ export class LidoSDKApr {
       postTotalEther: lastEvent.args.postTotalEther,
       postTotalShares: lastEvent.args.postTotalShares,
       timeElapsed,
-    })
+    });
 
     return smaApr;
   }
 
   private calculateApr(props: {
-    preTotalEther?: bigint;
-    preTotalShares?: bigint;
-    postTotalEther?: bigint;
-    postTotalShares?: bigint;
-    timeElapsed?: bigint;
+    preTotalEther: bigint;
+    preTotalShares: bigint;
+    postTotalEther: bigint;
+    postTotalShares: bigint;
+    timeElapsed: bigint;
   }): number {
     const {
       preTotalEther,
@@ -79,12 +74,6 @@ export class LidoSDKApr {
       postTotalShares,
       timeElapsed,
     } = props;
-
-    invariant(preTotalEther, 'preTotalEther is not defined');
-    invariant(preTotalShares, 'preTotalShares is not defined');
-    invariant(postTotalEther, 'postTotalEther is not defined');
-    invariant(postTotalShares, 'postTotalShares is not defined');
-    invariant(timeElapsed, 'timeElapsed is not defined');
 
     const preShareRate = (preTotalEther * BigInt(10 ** 27)) / preTotalShares;
     const postShareRate = (postTotalEther * BigInt(10 ** 27)) / postTotalShares;

--- a/packages/sdk/src/statistics/apr.ts
+++ b/packages/sdk/src/statistics/apr.ts
@@ -42,7 +42,7 @@ export class LidoSDKApr {
     invariant(lastEvent, 'Last event is not defined')
 
     const firstEvent = await this.events.stethEvents.getFirstRebaseEvent({
-      fromBlock: lastEvent.blockNumber, daysAgo: days
+      daysAgo: days, goBackFromBlock: lastEvent.blockNumber,
     })
     invariant(firstEvent, 'First event is not defined')
 
@@ -50,12 +50,16 @@ export class LidoSDKApr {
     invariant(lastEvent.args.reportTimestamp, 'Last event reportTimestamp is not defined')
     invariant(firstEvent.args.reportTimestamp, 'First event reportTimestamp is not defined')
 
+    const timeElapsed = firstEvent.args.timeElapsed + (
+      lastEvent.args.reportTimestamp - firstEvent.args.reportTimestamp
+    );
+
     const smaApr = this.calculateApr({
       preTotalEther: firstEvent.args.preTotalEther,
       preTotalShares: firstEvent.args.preTotalShares,
       postTotalEther: lastEvent.args.postTotalEther,
       postTotalShares: lastEvent.args.postTotalShares,
-      timeElapsed: firstEvent.args.timeElapsed + (lastEvent.args.reportTimestamp - firstEvent.args.reportTimestamp),
+      timeElapsed,
     })
 
     return smaApr;

--- a/playground/demo/events/index.tsx
+++ b/playground/demo/events/index.tsx
@@ -1,9 +1,11 @@
-import { Accordion } from '@lidofinance/lido-ui';
+import { Accordion, Input } from '@lidofinance/lido-ui';
 import { useWeb3 } from '@reef-knot/web3-react';
 import { Action } from 'components/action';
 import { useLidoSDK } from 'providers/sdk';
+import { useState } from 'react';
 
 export const EventsDemo = () => {
+  const [daysAgoValue, setDaysAgoValue] = useState<number>(0);
   const { events } = useLidoSDK();
 
   return (
@@ -12,6 +14,23 @@ export const EventsDemo = () => {
         title="Last Rebase event"
         action={() => events.stethEvents.getLastRebaseEvent()}
       />
+      <Action
+        title="First Rebase event"
+        action={() =>
+          events.stethEvents.getFirstRebaseEvent({
+            daysAgo: daysAgoValue
+          })
+        }
+      >
+        <Input
+          label="Days ago"
+          placeholder='7'
+          type="number"
+          min={0}
+          value={daysAgoValue}
+          onChange={(e) => setDaysAgoValue(e.target.valueAsNumber)}
+        />
+      </Action>
       <Action
         title="Last 10 Rebase events"
         action={() => events.stethEvents.getRebaseEvents({ count: 10 })}

--- a/playground/demo/events/index.tsx
+++ b/playground/demo/events/index.tsx
@@ -1,5 +1,4 @@
 import { Accordion, Input } from '@lidofinance/lido-ui';
-import { useWeb3 } from '@reef-knot/web3-react';
 import { Action } from 'components/action';
 import { useLidoSDK } from 'providers/sdk';
 import { useState } from 'react';
@@ -18,13 +17,13 @@ export const EventsDemo = () => {
         title="First Rebase event"
         action={() =>
           events.stethEvents.getFirstRebaseEvent({
-            daysAgo: daysAgoValue
+            days: daysAgoValue,
           })
         }
       >
         <Input
           label="Days ago"
-          placeholder='7'
+          placeholder="7"
           type="number"
           min={1}
           value={daysAgoValue}

--- a/playground/demo/events/index.tsx
+++ b/playground/demo/events/index.tsx
@@ -5,7 +5,7 @@ import { useLidoSDK } from 'providers/sdk';
 import { useState } from 'react';
 
 export const EventsDemo = () => {
-  const [daysAgoValue, setDaysAgoValue] = useState<number>(0);
+  const [daysAgoValue, setDaysAgoValue] = useState<number>(1);
   const { events } = useLidoSDK();
 
   return (
@@ -26,7 +26,7 @@ export const EventsDemo = () => {
           label="Days ago"
           placeholder='7'
           type="number"
-          min={0}
+          min={1}
           value={daysAgoValue}
           onChange={(e) => setDaysAgoValue(e.target.valueAsNumber)}
         />

--- a/playground/demo/statistics/index.tsx
+++ b/playground/demo/statistics/index.tsx
@@ -1,15 +1,33 @@
-import { Accordion } from '@lidofinance/lido-ui';
+import { Input, Accordion } from '@lidofinance/lido-ui';
 import { useWeb3 } from '@reef-knot/web3-react';
 import { Action } from 'components/action';
 import { useLidoSDK } from 'providers/sdk';
+import { useState } from 'react';
 
 export const StatisticsDemo = () => {
+  const [daysValue, setDaysValue] = useState<number>(0);
   const { statistics } = useLidoSDK();
 
   return (
     <Accordion summary="Statistic">
       <Action title="Last Apr" action={() => statistics.apr.getLastApr()} />
-      <Action title="SMA Apr" action={() => statistics.apr.getSmaApr({ days: 7 })} />
+      <Action
+        title="SMA Apr"
+        action={() =>
+          statistics.apr.getSmaApr({
+            days: daysValue
+          })
+        }
+      >
+        <Input
+          label="Days for APR"
+          placeholder="7"
+          type="number"
+          min={0}
+          value={daysValue}
+          onChange={(e) => setDaysValue(e.target.valueAsNumber)}
+        />
+      </Action>
     </Accordion>
   );
 };

--- a/playground/demo/statistics/index.tsx
+++ b/playground/demo/statistics/index.tsx
@@ -9,7 +9,7 @@ export const StatisticsDemo = () => {
   return (
     <Accordion summary="Statistic">
       <Action title="Last Apr" action={() => statistics.apr.getLastApr()} />
-      <Action title="SMA Apr" action={() => statistics.apr.getSmaApr()} />
+      <Action title="SMA Apr" action={() => statistics.apr.getSmaApr({ days: 7 })} />
     </Accordion>
   );
 };


### PR DESCRIPTION
### Description

The PR brings the ability of APR calculation for an arbitrary period using two `TokenRebased` events.

### Demo
<img src="https://github.com/lidofinance/lido-ethereum-sdk/assets/961317/4d63fb46-8a71-47b6-acdb-0100875bae27" width="30%" />
<img src="https://github.com/lidofinance/lido-ethereum-sdk/assets/961317/e7b78517-af00-423f-b060-865048181b37" width="30%" />


### Code review notes

- It's also proposed to perform the events search using day-long frames.
- Eth-RPC providers have various limits with events fetching (`eth_getLogs`), e.g.:
  - **Alchemy**
  > You can make eth_getLogs requests on any block range with a cap of 10K logs in the response OR a 2K block range with no cap on logs in the response and 150MB limit on the response size'
  - **Infura**
  > To prevent queries from consuming too many resources, eth_getLogs requests are currently limited by three constraints:
  >
  > A maximuim of 5,000 parameters in a single request
  > A maximum of 10,000 results can be returned by a single query
  > Query duration must not exceed 10 seconds
  - QuickNode
  > Please note that this RPC method have a block range limit of 10,000 blocks to ensure reliability, so it's best to break down queries into smaller chunks for faster responses and better error handling. For more information about the block range limit and how to avoid it, refer to this [FAQ](https://support.quicknode.com/hc/en-us/articles/10258449939473-Is-there-a-block-range-limit-for-querying-logs-and-events-)

### Testing notes

- Can check that 0days SMA APR is equal to the latest APR
- Mind the Holešky launch date is quite close (can't check long-spread periods)

### Checklist:

- [x]  Checked the changes locally.
- [x] Updated demos.


