### PR TITLE
Fix account hoistings

### DIFF
--- a/packages/sdk/src/common/constants.ts
+++ b/packages/sdk/src/common/constants.ts
@@ -28,11 +28,11 @@ export const LIDO_LOCATOR_BY_CHAIN: {
 };
 
 export const SUBRGRAPH_ID_BY_CHAIN: {
-  [key in CHAINS]: string;
+  [key in CHAINS]: string | null;
 } = {
   [CHAINS.Mainnet]: 'HXfMc1jPHfFQoccWd7VMv66km75FoxVHDMvsJj5vG5vf',
   [CHAINS.Goerli]: 'QmeDfGTuNbSoZ71zi3Ch4WNRbzALfiFPnJMYUFPinLiFNa',
-  [CHAINS.Holesky]: '',
+  [CHAINS.Holesky]: null,
 };
 
 export const EARLIEST_TOKEN_REBASED_EVENT: {

--- a/packages/sdk/src/core/__tests__/core-wallet.test.ts
+++ b/packages/sdk/src/core/__tests__/core-wallet.test.ts
@@ -37,7 +37,6 @@ describe('Core Wallet Tests', () => {
     const contractAddress = await web3Core.getContractAddress(
       isSteth ? LIDO_CONTRACT_NAMES.lido : LIDO_CONTRACT_NAMES.wsteth,
     );
-    console.log(web3Core.useWeb3Provider().account?.type);
     const address = await web3Core.getWeb3Address();
     const {
       chainId: permitChainId,

--- a/packages/sdk/src/core/core.ts
+++ b/packages/sdk/src/core/core.ts
@@ -35,6 +35,7 @@ import {
   VIEM_CHAINS,
   SUBRGRAPH_ID_BY_CHAIN,
   APPROX_SECONDS_PER_BLOCK,
+  NOOP,
 } from '../common/constants.js';
 
 import { LidoLocatorAbi } from './abi/lidoLocator.js';
@@ -50,6 +51,7 @@ import type {
   GetFeeDataResult,
   BlockArgumentType,
   BackArgumentType,
+  AccountValue,
 } from './types.js';
 import { TransactionCallbackStage } from './types.js';
 import { permitAbi } from './abi/permit.js';
@@ -205,9 +207,9 @@ export default class LidoSDKCore {
       deadline = LidoSDKCore.INFINITY_DEADLINE_VALUE,
     } = props;
     const web3Provider = this.useWeb3Provider();
-
+    const accountAddress = await this.getWeb3Address(account);
     const { contract, domain } = await this.getPermitContractData(token);
-    const nonce = await contract.read.nonces([account]);
+    const nonce = await contract.read.nonces([accountAddress]);
 
     invariant(
       web3Provider.account,
@@ -220,7 +222,7 @@ export default class LidoSDKCore {
       types: PERMIT_MESSAGE_TYPES,
       primaryType: 'Permit',
       message: {
-        owner: account,
+        owner: accountAddress,
         spender,
         value: amount,
         nonce,
@@ -237,7 +239,7 @@ export default class LidoSDKCore {
       deadline,
       nonce: nonce,
       chainId: domain.chainId,
-      owner: account,
+      owner: accountAddress,
       spender: spender,
     };
   }
@@ -313,7 +315,9 @@ export default class LidoSDKCore {
   }
 
   @Logger('Utils:')
-  public async getWeb3Address(): Promise<Address> {
+  public async getWeb3Address(accountValue?: AccountValue): Promise<Address> {
+    if (typeof accountValue === 'string') return accountValue;
+    if (accountValue) return accountValue.address;
     const web3Provider = this.useWeb3Provider();
 
     if (web3Provider.account) return web3Provider.account.address;
@@ -361,13 +365,8 @@ export default class LidoSDKCore {
 
   @Logger('Utils:')
   @Cache(30 * 60 * 1000, ['chain.id'])
-  public getSubgraphId(): string {
+  public getSubgraphId(): string | null {
     const id = SUBRGRAPH_ID_BY_CHAIN[this.chainId];
-    invariant(
-      id,
-      `Subgraph is not supported for chain ${this.chainId}`,
-      ERROR_CODE.NOT_SUPPORTED,
-    );
     return id;
   }
 
@@ -447,12 +446,17 @@ export default class LidoSDKCore {
   public async performTransaction(
     props: PerformTransactionOptions,
   ): Promise<TransactionResult> {
-    this.useWeb3Provider();
-    const { account, callback, getGasLimit, sendTransaction } = props;
-    const isContract = await this.isContract(account);
+    const provider = this.useWeb3Provider();
+    const { account, callback = NOOP, getGasLimit, sendTransaction } = props;
+    const accountAddress = await this.getWeb3Address(account);
+    const isContract = await this.isContract(accountAddress);
 
+    // we need account to be defined for transactions so we fallback in this order
+    // 1. whatever user passed
+    // 2. hoisted account
+    // 3. just address (this will break on local accounts as per viem behavior)
     const overrides: TransactionOptions = {
-      account,
+      account: account ?? provider.account ?? accountAddress,
       chain: this.chain,
       gas: undefined,
       maxFeePerGas: undefined,

--- a/packages/sdk/src/core/index.ts
+++ b/packages/sdk/src/core/index.ts
@@ -7,6 +7,7 @@ export type {
   TransactionCallbackProps,
   TransactionResult,
   EtherValue,
+  AccountValue,
   PermitSignature,
   GetFeeDataResult,
   PopulatedTransaction,
@@ -20,5 +21,6 @@ export type {
   PermitCallback,
   PermitCallbackProps,
   TransactionOptions,
+  CommonTransactionProps,
 } from './types.js';
 export { TransactionCallbackStage } from './types.js';

--- a/packages/sdk/src/core/types.ts
+++ b/packages/sdk/src/core/types.ts
@@ -7,11 +7,14 @@ import type {
   Chain,
   FormattedTransactionRequest,
   BlockTag,
+  Account,
 } from 'viem';
 
 import { LIDO_TOKENS, SUPPORTED_CHAINS } from '../common/constants.js';
 import { SDKError } from '../common/utils/sdk-error.js';
 import type LidoSDKCore from './core.js';
+
+// Constructor Props
 
 export type LOG_MODE = 'info' | 'debug' | 'none';
 
@@ -39,7 +42,11 @@ export type LidoSDKCommonProps =
     }
   | ({ core: undefined } & LidoSDKCoreProps);
 
+// Method Props primitives
+
 export type EtherValue = string | bigint;
+
+export type AccountValue = Address | Account;
 
 export enum TransactionCallbackStage {
   'PERMIT' = 'permit',
@@ -52,6 +59,11 @@ export enum TransactionCallbackStage {
   'ERROR' = 'error',
 }
 
+export type CommonTransactionProps = {
+  callback?: TransactionCallback;
+  account?: AccountValue;
+};
+
 export type PerformTransactionGasLimit = (
   overrides: TransactionOptions,
 ) => Promise<bigint>;
@@ -60,15 +72,13 @@ export type PerformTransactionSendTransaction = (
   override: TransactionOptions,
 ) => Promise<Hash>;
 
-export type PerformTransactionOptions = {
-  callback: TransactionCallback;
-  account: Address;
+export type PerformTransactionOptions = CommonTransactionProps & {
   getGasLimit: PerformTransactionGasLimit;
   sendTransaction: PerformTransactionSendTransaction;
 };
 
 export type TransactionOptions = {
-  account: Address;
+  account: AccountValue;
   chain: Chain;
   gas?: bigint;
   maxFeePerGas?: bigint;
@@ -123,16 +133,9 @@ export type PermitSignature = {
 export type SignPermitProps = {
   token: (typeof LIDO_TOKENS)['steth'] | (typeof LIDO_TOKENS)['wsteth'];
   amount: bigint;
-  account: Address;
+  account?: AccountValue;
   spender: Address;
   deadline?: bigint;
-};
-
-export type GetFeeDataResult = {
-  lastBaseFeePerGas: bigint;
-  maxFeePerGas: bigint;
-  maxPriorityFeePerGas: bigint;
-  gasPrice: bigint;
 };
 
 export type NonPendingBlockTag = Exclude<BlockTag, 'pending'>;
@@ -163,3 +166,12 @@ export type BackArgumentType =
       seconds?: undefined;
       blocks: bigint;
     };
+
+// Core methods
+
+export type GetFeeDataResult = {
+  lastBaseFeePerGas: bigint;
+  maxFeePerGas: bigint;
+  maxPriorityFeePerGas: bigint;
+  gasPrice: bigint;
+};

--- a/packages/sdk/src/erc20/index.ts
+++ b/packages/sdk/src/erc20/index.ts
@@ -7,5 +7,4 @@ export type {
   ApproveProps,
   TransferProps,
   SignTokenPermitProps,
-  TransactionProps,
 } from './types.js';

--- a/packages/sdk/src/erc20/types.ts
+++ b/packages/sdk/src/erc20/types.ts
@@ -5,7 +5,7 @@ import {
   type TransactionCallback,
   type EtherValue,
 } from '../core/index.js';
-import { SignPermitProps } from '../core/types.js';
+import { CommonTransactionProps, SignPermitProps } from '../core/types.js';
 
 export type LidoSDKErc20Props = LidoSDKCoreProps & {
   core?: LidoSDKCore;
@@ -16,25 +16,23 @@ export type TransactionProps = {
   callback?: TransactionCallback;
 };
 
-export type InnerTransactionProps = Required<TransactionProps>;
+export type InnerTransactionProps = Required<CommonTransactionProps>;
 
-export type ParsedTransactionProps<TProps extends TransactionProps> = Omit<
-  TProps,
-  'callback'
-> & {
-  callback: NonNullable<TProps['callback']>;
-} & (TProps extends { amount: EtherValue } ? { amount: bigint } : {});
+export type ParsedTransactionProps<TProps extends CommonTransactionProps> =
+  Omit<TProps, 'callback'> & {
+    callback: NonNullable<TProps['callback']>;
+  } & (TProps extends { amount: EtherValue } ? { amount: bigint } : {});
 
 export type TransferProps = {
   amount: EtherValue;
   to: Address;
   from?: Address;
-} & TransactionProps;
+} & CommonTransactionProps;
 
 export type ApproveProps = {
   amount: EtherValue;
   to: Address;
-} & TransactionProps;
+} & CommonTransactionProps;
 
 export type AllowanceProps = {
   account: Address;

--- a/packages/sdk/src/rewards/types.ts
+++ b/packages/sdk/src/rewards/types.ts
@@ -83,7 +83,7 @@ type GetRewardsCommonResult = {
 
 export type GetRewardsFromSubgraphOptions = GetRewardsOptions & {
   stepEntities?: number;
-  getSubgraphUrl: (id: string, chainId: number) => string;
+  getSubgraphUrl: (id: string | null, chainId: number) => string;
 };
 
 export type GetRewardsFromSubgraphResult = {

--- a/packages/sdk/src/shares/shares.ts
+++ b/packages/sdk/src/shares/shares.ts
@@ -71,9 +71,10 @@ export class LidoSDKShares {
     to,
     amount: _amount,
     callback = NOOP,
-    from = account,
+    from: _from,
   }: SharesTransferProps): Promise<TransactionResult> {
     this.core.useWeb3Provider();
+    const from = _from ?? (await this.core.getWeb3Address(account));
     const amount = parseValue(_amount);
     const contract = await this.getContractStETHshares();
 
@@ -95,8 +96,9 @@ export class LidoSDKShares {
     account,
     to,
     amount: _amount,
-    from = account,
+    from: _from,
   }: NoCallback<SharesTransferProps>) {
+    const from = _from ?? (await this.core.getWeb3Address(account));
     const amount = parseValue(_amount);
     const contract = await this.getContractStETHshares();
 
@@ -117,9 +119,10 @@ export class LidoSDKShares {
     account,
     to,
     amount: _amount,
-    from = account,
+    from: _from,
   }: NoCallback<SharesTransferProps>) {
     const amount = parseValue(_amount);
+    const from = _from ?? (await this.core.getWeb3Address(account));
     const contract = await this.getContractStETHshares();
     return contract.simulate.transferSharesFrom([from, to, amount], {
       account,

--- a/packages/sdk/src/shares/types.ts
+++ b/packages/sdk/src/shares/types.ts
@@ -1,18 +1,16 @@
 import type { Address } from 'viem';
 import type {
+  CommonTransactionProps,
   EtherValue,
   LidoSDKCommonProps,
-  TransactionCallback,
 } from '../core/types.js';
 
 export type LidoSDKSharesProps = LidoSDKCommonProps;
 
-export type SharesTransferProps = {
-  account: Address;
+export type SharesTransferProps = CommonTransactionProps & {
   from?: Address;
   to: Address;
   amount: EtherValue;
-  callback?: TransactionCallback;
 };
 
 export type SharesTotalSupplyResult = {

--- a/packages/sdk/src/stake/types.ts
+++ b/packages/sdk/src/stake/types.ts
@@ -1,20 +1,16 @@
 import { type Address, type Hash, type TransactionReceipt } from 'viem';
-import { LidoSDKCommonProps, TransactionCallback } from '../core/types.js';
+import { CommonTransactionProps, LidoSDKCommonProps } from '../core/types.js';
 import { EtherValue } from '../core/types.js';
 
 export type LidoSDKStakeProps = LidoSDKCommonProps;
 
-export type StakeProps = {
+export type StakeProps = CommonTransactionProps & {
   value: EtherValue;
-  account: Address;
-  callback?: TransactionCallback;
   referralAddress?: Address;
 };
 
-export type StakeInnerProps = {
+export type StakeInnerProps = CommonTransactionProps & {
   value: bigint;
-  account: Address;
-  callback: TransactionCallback;
   referralAddress: Address;
 };
 

--- a/packages/sdk/src/unsteth/index.ts
+++ b/packages/sdk/src/unsteth/index.ts
@@ -7,6 +7,5 @@ export {
   type UnstethApproveProps,
   type UnstethApprovedForProps,
   type UnstethIsApprovedForAllProps,
-  type UnstethCommonTransactionProps,
   type UnstethNFTstatus,
 } from './types.js';

--- a/packages/sdk/src/unsteth/types.ts
+++ b/packages/sdk/src/unsteth/types.ts
@@ -1,6 +1,10 @@
 import { type Hash, type Address, type ContractFunctionResult } from 'viem';
 import LidoSDKCore from '../core/core.js';
-import { TransactionCallback, type LidoSDKCoreProps } from '../core/types.js';
+import {
+  TransactionCallback,
+  type LidoSDKCoreProps,
+  CommonTransactionProps,
+} from '../core/types.js';
 import { type unstethAbi } from './abi/unsteth-abi.js';
 
 export type LidoSDKUnstETHProps = {
@@ -14,33 +18,27 @@ export type UnstethNFTstatus = ContractFunctionResult<
 
 export type UnstethNFT = { id: bigint } & UnstethNFTstatus;
 
-export type UnstethCommonTransactionProps = {
-  account: Address;
-  callback?: TransactionCallback;
-};
-
-export type ParsedProps<TProps extends UnstethCommonTransactionProps> = Omit<
+export type ParsedProps<TProps extends CommonTransactionProps> = Omit<
   TProps,
   'callback'
-> &
-  Required<UnstethCommonTransactionProps>;
+> & { callback: TransactionCallback };
 
 export type UnstethTransferProps = {
   to: Address;
   id: bigint;
   from?: Address;
   data?: Hash;
-} & UnstethCommonTransactionProps;
+} & CommonTransactionProps;
 
 export type UnstethApproveProps = {
   to?: Address;
   id: bigint;
-} & UnstethCommonTransactionProps;
+} & CommonTransactionProps;
 
 export type UnstethApproveAllProps = {
   to: Address;
   allow: boolean;
-} & UnstethCommonTransactionProps;
+} & CommonTransactionProps;
 
 export type UnstethApprovedForProps = {
   account: Address;

--- a/packages/sdk/src/withdraw/request/approve.ts
+++ b/packages/sdk/src/withdraw/request/approve.ts
@@ -89,6 +89,7 @@ export class LidoSDKWithdrawApprove {
     props: NoCallback<WithdrawApproveProps>,
   ): Promise<PopulatedTransaction> {
     const { token, account, amount: _amount } = props;
+    const accountAddress = await this.bus.core.getWeb3Address(account);
     const amount = parseValue(_amount);
     const isSteth = token === 'stETH';
 
@@ -101,7 +102,7 @@ export class LidoSDKWithdrawApprove {
     ) as Awaited<ReturnType<typeof this.bus.contract.getContractStETH>>;
 
     return {
-      from: account,
+      from: accountAddress,
       to: contract.address,
       data: encodeFunctionData({
         abi: contract.abi,
@@ -119,7 +120,7 @@ export class LidoSDKWithdrawApprove {
     account,
     token,
     amount,
-  }: NoCallback<WithdrawApproveProps>): Promise<bigint> {
+  }: Required<NoCallback<WithdrawApproveProps>>): Promise<bigint> {
     const value = parseValue(amount);
     const isSteth = token === 'stETH';
     let estimateGasMethod;
@@ -137,7 +138,7 @@ export class LidoSDKWithdrawApprove {
     const gasLimit = await estimateGasMethod.call(
       this,
       [addressWithdrawalsQueue, value],
-      { account },
+      { account: account },
     );
 
     return gasLimit;

--- a/packages/sdk/src/withdraw/request/request.ts
+++ b/packages/sdk/src/withdraw/request/request.ts
@@ -75,7 +75,14 @@ export class LidoSDKWithdrawRequest extends BusModule {
   public async requestWithdrawal(
     props: RequestProps,
   ): Promise<TransactionResult> {
-    const { account, token, receiver = account, callback = NOOP } = props;
+    const accountAddress = await this.bus.core.getWeb3Address(props.account);
+    const {
+      account,
+      token,
+      receiver = accountAddress,
+      callback = NOOP,
+    } = props;
+
     const requests =
       props.requests ?? (await this.splitAmountToRequests(props));
     const isSteth = token === 'stETH';
@@ -109,10 +116,11 @@ export class LidoSDKWithdrawRequest extends BusModule {
   public async requestWithdrawalSimulateTx(
     props: NoCallback<RequestProps>,
   ): Promise<SimulateContractReturnType> {
+    const accountAddress = await this.bus.core.getWeb3Address(props.account);
     const {
       token,
       account,
-      receiver = account,
+      receiver = accountAddress,
       amount = 0n,
       requests: _requests,
     } = props;
@@ -123,8 +131,8 @@ export class LidoSDKWithdrawRequest extends BusModule {
 
     const args = [requests, receiver] as const;
     const result = await (isSteth
-      ? contract.simulate.requestWithdrawals(args)
-      : contract.simulate.requestWithdrawalsWstETH(args));
+      ? contract.simulate.requestWithdrawals(args, { account })
+      : contract.simulate.requestWithdrawalsWstETH(args, { account }));
 
     return result;
   }
@@ -134,10 +142,10 @@ export class LidoSDKWithdrawRequest extends BusModule {
   public async requestWithdrawalPopulateTx(
     props: NoCallback<RequestWithPermitProps>,
   ): Promise<PopulatedTransaction> {
+    const accountAddress = await this.bus.core.getWeb3Address(props.account);
     const {
       token,
-      account,
-      receiver = account,
+      receiver = accountAddress,
       amount = 0n,
       requests: _requests,
     } = props;
@@ -152,7 +160,7 @@ export class LidoSDKWithdrawRequest extends BusModule {
       : ('requestWithdrawalsWstETH' as const);
 
     return {
-      from: account,
+      from: accountAddress,
       to: contract.address,
       data: encodeFunctionData({
         abi: contract.abi,
@@ -167,10 +175,11 @@ export class LidoSDKWithdrawRequest extends BusModule {
   public async requestWithdrawalWithPermit(
     props: RequestWithPermitProps,
   ): Promise<TransactionResult> {
+    const accountAddress = await this.bus.core.getWeb3Address(props.account);
     const {
       account,
       token,
-      receiver = account,
+      receiver = accountAddress,
       callback = NOOP,
       permit: permitProp,
     } = props;
@@ -184,7 +193,7 @@ export class LidoSDKWithdrawRequest extends BusModule {
       permit = permitProp;
     } else {
       callback({ stage: TransactionCallbackStage.PERMIT });
-      const isContract = await this.bus.core.isContract(account);
+      const isContract = await this.bus.core.isContract(accountAddress);
       invariant(
         !isContract,
         'Cannot sign permit for contract',
@@ -240,10 +249,11 @@ export class LidoSDKWithdrawRequest extends BusModule {
   public async requestWithdrawalWithPermitSimulateTx(
     props: NoCallback<RequirePermit<RequestWithPermitProps>>,
   ): Promise<SimulateContractReturnType> {
+    const accountAddress = await this.bus.core.getWeb3Address(props.account);
     const {
       token,
       account,
-      receiver = account,
+      receiver = accountAddress,
       permit,
       amount = 0n,
       requests: _requests,
@@ -255,8 +265,10 @@ export class LidoSDKWithdrawRequest extends BusModule {
 
     const args = [requests, receiver, permit] as const;
     const result = await (isSteth
-      ? contract.simulate.requestWithdrawalsWithPermit(args)
-      : contract.simulate.requestWithdrawalsWstETHWithPermit(args));
+      ? contract.simulate.requestWithdrawalsWithPermit(args, { account })
+      : contract.simulate.requestWithdrawalsWstETHWithPermit(args, {
+          account,
+        }));
 
     return result;
   }
@@ -266,10 +278,10 @@ export class LidoSDKWithdrawRequest extends BusModule {
   public async requestWithdrawalWithPermitPopulateTx(
     props: NoCallback<RequirePermit<RequestWithPermitProps>>,
   ): Promise<PopulatedTransaction> {
+    const accountAddress = await this.bus.core.getWeb3Address(props.account);
     const {
       token,
-      account,
-      receiver = account,
+      receiver = accountAddress,
       permit,
       amount = 0n,
       requests: _requests,
@@ -285,7 +297,7 @@ export class LidoSDKWithdrawRequest extends BusModule {
       : ('requestWithdrawalsWstETHWithPermit' as const);
 
     return {
-      from: account,
+      from: accountAddress,
       to: contract.address,
       data: encodeFunctionData({
         abi: contract.abi,

--- a/packages/sdk/src/withdraw/request/types.ts
+++ b/packages/sdk/src/withdraw/request/types.ts
@@ -1,6 +1,6 @@
 import type { Hash, Address } from 'viem';
 
-import type { EtherValue, TransactionCallback } from '../../core/index.js';
+import type { CommonTransactionProps, EtherValue } from '../../core/index.js';
 import { LIDO_TOKENS } from '../../common/constants.js';
 
 export type WithdrawableTokens =
@@ -23,21 +23,19 @@ export type PermitProps = PermitWstETHStETHProps & {
   token: WithdrawableTokens;
 };
 
-export type RequestProps = {
-  account: Address;
+export type RequestProps = CommonTransactionProps & {
   receiver?: Address;
   token: WithdrawableTokens;
-  callback?: TransactionCallback;
 } & (
-  | {
-      amount: EtherValue;
-      requests?: undefined;
-    }
-  | {
-      requests: readonly bigint[];
-      amount?: undefined;
-    }
-);
+    | {
+        amount: EtherValue;
+        requests?: undefined;
+      }
+    | {
+        requests: readonly bigint[];
+        amount?: undefined;
+      }
+  );
 
 export type SignedPermit = {
   value: bigint;
@@ -55,11 +53,9 @@ export type RequirePermit<TProps> = Omit<TProps, 'permit'> & {
   permit: SignedPermit;
 };
 
-export type WithdrawApproveProps = {
-  account: Address;
+export type WithdrawApproveProps = CommonTransactionProps & {
   amount: EtherValue;
   token: WithdrawableTokens;
-  callback?: TransactionCallback;
 };
 
 export type GetAllowanceProps = {

--- a/packages/sdk/src/wrap/types.ts
+++ b/packages/sdk/src/wrap/types.ts
@@ -1,24 +1,20 @@
-import { FormattedTransactionRequest, type Address } from 'viem';
-import {
-  type LidoSDKCommonProps,
-  type EtherValue,
-  type TransactionCallback,
+import type { FormattedTransactionRequest } from 'viem';
+import type {
+  LidoSDKCommonProps,
+  EtherValue,
+  CommonTransactionProps,
 } from '../core/types.js';
 
 export type LidoSDKWrapProps = LidoSDKCommonProps;
 
-export type WrapProps = {
+export type WrapProps = CommonTransactionProps & {
   value: EtherValue;
-  account: Address;
-  callback?: TransactionCallback;
 };
 
 export type WrapPropsWithoutCallback = Omit<WrapProps, 'callback'>;
 
-export type WrapInnerProps = {
+export type WrapInnerProps = CommonTransactionProps & {
   value: bigint;
-  account: Address;
-  callback: TransactionCallback;
 };
 
 export type PopulatedTx = Omit<FormattedTransactionRequest, 'type'>;

--- a/packages/sdk/src/wrap/wrap.ts
+++ b/packages/sdk/src/wrap/wrap.ts
@@ -115,12 +115,12 @@ export class LidoSDKWrap {
     props: WrapProps,
   ): Promise<PopulatedTransaction> {
     const { value, account } = this.parseProps(props);
-
+    const accountAddress = await this.core.getWeb3Address(account);
     const address = await this.contractAddressWstETH();
 
     return {
       to: address,
-      from: account,
+      from: accountAddress,
       value,
     };
   }
@@ -131,10 +131,11 @@ export class LidoSDKWrap {
     props: WrapPropsWithoutCallback,
   ): Promise<bigint> {
     const { value, account } = this.parseProps(props);
+    const accountAddress = await this.core.getWeb3Address(account);
 
     const address = await this.contractAddressWstETH();
     return this.core.rpcProvider.estimateGas({
-      account,
+      account: accountAddress,
       to: address,
       value,
     });
@@ -162,11 +163,12 @@ export class LidoSDKWrap {
     props: WrapPropsWithoutCallback,
   ): Promise<PopulatedTransaction> {
     const { value, account } = this.parseProps(props);
+    const accountAddress = await this.core.getWeb3Address(account);
     const address = await this.contractAddressWstETH();
 
     return {
       to: address,
-      from: account,
+      from: accountAddress,
       data: encodeFunctionData({
         abi,
         functionName: 'wrap',
@@ -187,7 +189,6 @@ export class LidoSDKWrap {
       address,
       abi,
       account,
-
       functionName: 'wrap',
       args: [value],
     });
@@ -233,13 +234,14 @@ export class LidoSDKWrap {
     props: WrapPropsWithoutCallback,
   ): Promise<Omit<FormattedTransactionRequest, 'type'>> {
     const { value, account } = this.parseProps(props);
+    const accountAddress = await this.core.getWeb3Address(account);
 
     const stethContract = await this.getPartialContractSteth();
     const wstethContractAddress = await this.contractAddressWstETH();
 
     return {
       to: stethContract.address,
-      from: account,
+      from: accountAddress,
       data: encodeFunctionData({
         abi: stethPartialAbi,
         functionName: 'approve',
@@ -291,11 +293,12 @@ export class LidoSDKWrap {
     props: Omit<WrapProps, 'callback'>,
   ): Promise<PopulatedTransaction> {
     const { value, account } = this.parseProps(props);
+    const accountAddress = await this.core.getWeb3Address(account);
     const to = await this.contractAddressWstETH();
 
     return {
       to,
-      from: account,
+      from: accountAddress,
       data: encodeFunctionData({
         abi: abi,
         functionName: 'unwrap',


### PR DESCRIPTION
### Description

- [x] For all transactions and transaction related methods viem accounts objects are supported and account is not required as you can hoist to wallet client
- [x] more consistent and reusable types
- [x] allow null id for subgraph as id is only relevant to mainnet. You might not need id for holesky. 
- [x] `core.getWeb3Address` now accepts optional `Account | Address`  and extracts addres from them.


### Checklist:

- [x]  Checked the changes locally.
- [x]  Created/updated unit tests.
- [ ]  Created/updated README.md.

