### PR TITLE
Fix cache collusion

### DIFF
--- a/packages/sdk/MIGRATION.md
+++ b/packages/sdk/MIGRATION.md
@@ -6,6 +6,7 @@
 - some methods that did't previously use `web3Provider` but accepted `account` prop (like `populate...` or `simulate...`) now will require `web3Provider` if `account` prop is omitted in order to access possibly hoisted account
 - All exports from individual modules are now available from root export `@lidofinance/lido-ethereum-sdk`
 - For all modules constructor arguments typings are now more strict. Disallow incorrect combinations (e.g. `core` and `rpcUrls` at same time)
+- All dedicated SDK modules now use `type LidoSDKCommonProps` for constructor options and no longer export separate type
 
 ## Core
 

--- a/packages/sdk/src/common/class-primitives/cacheable.ts
+++ b/packages/sdk/src/common/class-primitives/cacheable.ts
@@ -1,0 +1,6 @@
+export abstract class LidoSDKCacheable {
+  protected accessor cache = new Map<
+    string,
+    { data: any; timestamp: number }
+  >();
+}

--- a/packages/sdk/src/common/class-primitives/sdk-module.ts
+++ b/packages/sdk/src/common/class-primitives/sdk-module.ts
@@ -1,0 +1,16 @@
+import LidoSDKCore from '../../core/core.js';
+import type { LidoSDKCommonProps } from '../../core/types.js';
+import { version } from '../../version.js';
+import { LidoSDKCacheable } from './cacheable.js';
+
+export abstract class LidoSDKModule extends LidoSDKCacheable {
+  readonly core: LidoSDKCore;
+
+  constructor(props: LidoSDKCommonProps) {
+    super();
+    const { core } = props;
+
+    if (core) this.core = core;
+    else this.core = new LidoSDKCore(props, version);
+  }
+}

--- a/packages/sdk/src/common/decorators/cache.ts
+++ b/packages/sdk/src/common/decorators/cache.ts
@@ -1,3 +1,4 @@
+import { LidoSDKCacheable } from '../class-primitives/cacheable.js';
 import { isBigint } from '../utils/index.js';
 
 import { callConsoleMessage } from './utils.js';
@@ -26,9 +27,11 @@ const getDecoratorArgsString = function <This>(this: This, args?: string[]) {
 };
 
 export const Cache = function (timeMs = 0, cacheArgs?: string[]) {
-  const cache = new Map<string, { data: any; timestamp: number }>();
-
-  return function CacheMethod<This, Args extends any[], Return>(
+  return function CacheMethod<
+    This extends LidoSDKCacheable,
+    Args extends any[],
+    Return,
+  >(
     originalMethod: (this: This, ...args: Args) => Return,
     context: ClassMethodDecoratorContext<
       This,
@@ -37,6 +40,7 @@ export const Cache = function (timeMs = 0, cacheArgs?: string[]) {
   ) {
     const methodName = String(context.name);
     const replacementMethod = function (this: This, ...args: Args): Return {
+      const cache = this.cache;
       const decoratorArgsKey = getDecoratorArgsString.call(this, cacheArgs);
       const argsKey = serializeArgs(args);
       const cacheKey = `${methodName}:${decoratorArgsKey}:${argsKey}`;

--- a/packages/sdk/src/core/core.ts
+++ b/packages/sdk/src/core/core.ts
@@ -55,8 +55,9 @@ import type {
 } from './types.js';
 import { TransactionCallbackStage } from './types.js';
 import { permitAbi } from './abi/permit.js';
+import { LidoSDKCacheable } from '../common/class-primitives/cacheable.js';
 
-export default class LidoSDKCore {
+export default class LidoSDKCore extends LidoSDKCacheable {
   public static readonly INFINITY_DEADLINE_VALUE = maxUint256;
   private static readonly MS_PER_DAY = 86400000n;
 
@@ -73,6 +74,7 @@ export default class LidoSDKCore {
   }
 
   constructor(props: LidoSDKCoreProps, version?: string) {
+    super();
     this.chainId = props.chainId;
     this.rpcUrls = props.rpcUrls;
     this.logMode = props.logMode ?? 'info';

--- a/packages/sdk/src/erc20/erc20.ts
+++ b/packages/sdk/src/erc20/erc20.ts
@@ -1,9 +1,7 @@
 import { EtherValue, LidoSDKCore } from '../core/index.js';
-import { version } from '../version.js';
 import type {
   AllowanceProps,
   ApproveProps,
-  LidoSDKErc20Props,
   ParsedTransactionProps,
   SignTokenPermitProps,
   TransferProps,
@@ -21,6 +19,7 @@ import {
 } from 'viem';
 import { NOOP, PERMIT_MESSAGE_TYPES } from '../common/constants.js';
 import { parseValue } from '../common/utils/parse-value.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 import type {
   CommonTransactionProps,
   NoCallback,
@@ -30,22 +29,13 @@ import type {
 } from '../core/types.js';
 import { splitSignature } from '@ethersproject/bytes';
 
-export abstract class AbstractLidoSDKErc20 {
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKErc20Props) {
-    const { core, ...rest } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(rest, version);
-  }
-
+export abstract class AbstractLidoSDKErc20 extends LidoSDKModule {
   // Contract
 
   public abstract contractAddress(): Promise<Address>;
 
   @Logger('Contracts:')
-  @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressWstETH'])
+  @Cache(30 * 60 * 1000, ['core.chain.id'])
   public async getContract(): Promise<
     GetContractReturnType<typeof erc20abi, PublicClient, WalletClient>
   > {

--- a/packages/sdk/src/erc20/index.ts
+++ b/packages/sdk/src/erc20/index.ts
@@ -2,7 +2,6 @@ export { AbstractLidoSDKErc20 } from './erc20.js';
 export { LidoSDKstETH } from './steth.js';
 export { LidoSDKwstETH } from './wsteth.js';
 export type {
-  LidoSDKErc20Props,
   AllowanceProps,
   ApproveProps,
   TransferProps,

--- a/packages/sdk/src/erc20/types.ts
+++ b/packages/sdk/src/erc20/types.ts
@@ -1,15 +1,6 @@
 import { Address } from 'viem';
-import {
-  type LidoSDKCoreProps,
-  type LidoSDKCore,
-  type TransactionCallback,
-  type EtherValue,
-} from '../core/index.js';
+import { type TransactionCallback, type EtherValue } from '../core/index.js';
 import { CommonTransactionProps, SignPermitProps } from '../core/types.js';
-
-export type LidoSDKErc20Props = LidoSDKCoreProps & {
-  core?: LidoSDKCore;
-};
 
 export type TransactionProps = {
   account: Address;

--- a/packages/sdk/src/events/events.ts
+++ b/packages/sdk/src/events/events.ts
@@ -1,12 +1,12 @@
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
+import { LidoSDKCommonProps } from '../core/types.js';
 
 import { LidoSDKStethEvents } from './steth-events.js';
-import type { LidoSDKEventsProps } from './types.js';
 
 export class LidoSDKEvents extends LidoSDKModule {
   readonly stethEvents: LidoSDKStethEvents;
 
-  constructor(props: LidoSDKEventsProps) {
+  constructor(props: LidoSDKCommonProps) {
     super(props);
 
     this.stethEvents = new LidoSDKStethEvents({ ...props, core: this.core });

--- a/packages/sdk/src/events/events.ts
+++ b/packages/sdk/src/events/events.ts
@@ -1,18 +1,13 @@
-import { LidoSDKCore } from '../core/index.js';
-import { version } from '../version.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 import { LidoSDKStethEvents } from './steth-events.js';
 import type { LidoSDKEventsProps } from './types.js';
 
-export class LidoSDKEvents {
-  readonly core: LidoSDKCore;
+export class LidoSDKEvents extends LidoSDKModule {
   readonly stethEvents: LidoSDKStethEvents;
 
   constructor(props: LidoSDKEventsProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
+    super(props);
 
     this.stethEvents = new LidoSDKStethEvents({ ...props, core: this.core });
   }

--- a/packages/sdk/src/events/steth-events.ts
+++ b/packages/sdk/src/events/steth-events.ts
@@ -6,14 +6,11 @@ import type {
   WalletClient,
 } from 'viem';
 
-import { LidoSDKCore } from '../core/index.js';
 import { Logger, Cache, ErrorHandler } from '../common/decorators/index.js';
 import { LIDO_CONTRACT_NAMES } from '../common/constants.js';
-import { version } from '../version.js';
 
 import { StethEventsAbi } from './abi/stethEvents.js';
 import {
-  type LidoSDKEventsProps,
   RebaseEvent,
   GetRebaseEventsProps,
   GetLastRebaseEventsProps,
@@ -24,21 +21,14 @@ import {
   invariantArgument,
 } from '../common/utils/sdk-error.js';
 import { requestWithBlockStep } from '../rewards/utils.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 const BLOCKS_BY_DAY = 7600n;
 const REBASE_EVENT_ABI_INDEX = 8;
 const DAYS_LIMIT = 7;
 
-export class LidoSDKStethEvents {
+export class LidoSDKStethEvents extends LidoSDKModule {
   static readonly DEFAULT_STEP_BLOCK = 50000;
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKEventsProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
-  }
 
   // Contracts
 

--- a/packages/sdk/src/events/types.ts
+++ b/packages/sdk/src/events/types.ts
@@ -1,12 +1,7 @@
-import { Log } from 'viem';
-import {
-  BackArgumentType,
-  BlockArgumentType,
-  LidoSDKCommonProps,
-} from '../core/types.js';
+import type { Log } from 'viem';
+import type { BackArgumentType, BlockArgumentType } from '../core/types.js';
 import type { StethEventsAbi } from './abi/stethEvents.js';
 
-export type LidoSDKEventsProps = LidoSDKCommonProps;
 export type RebaseEvent = Log<
   bigint,
   number,

--- a/packages/sdk/src/rewards/index.ts
+++ b/packages/sdk/src/rewards/index.ts
@@ -1,6 +1,5 @@
 export { LidoSDKRewards } from './rewards.js';
 export {
-  type LidoSDKRewardsProps,
   type GetRewardsFromChainResult,
   type GetRewardsFromChainOptions,
   type GetRewardsFromSubgraphOptions,

--- a/packages/sdk/src/rewards/rewards.ts
+++ b/packages/sdk/src/rewards/rewards.ts
@@ -5,9 +5,9 @@ import {
   getContract,
   zeroAddress,
 } from 'viem';
-import { LidoSDKCore } from '../core/index.js';
 import { Logger, ErrorHandler, Cache } from '../common/decorators/index.js';
-import { version } from '../version.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
+
 import { rewardsEventsAbi } from './abi/rewardsEvents.js';
 import {
   type GetRewardsFromChainOptions,
@@ -15,7 +15,6 @@ import {
   type GetRewardsFromSubgraphOptions,
   type GetRewardsFromSubgraphResult,
   type GetRewardsOptions,
-  type LidoSDKRewardsProps,
   type Reward,
   type RewardsChainEvents,
   type RewardsSubgraphEvents,
@@ -43,17 +42,10 @@ import {
 } from '../index.js';
 import { LidoSDKApr } from '../statistics/apr.js';
 
-export class LidoSDKRewards {
+export class LidoSDKRewards extends LidoSDKModule {
   private static readonly PRECISION = 10n ** 27n;
   private static readonly DEFAULT_STEP_ENTITIES = 1000;
   private static readonly DEFAULT_STEP_BLOCK = 50000;
-
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKRewardsProps) {
-    if (props.core) this.core = props.core;
-    else this.core = new LidoSDKCore(props, version);
-  }
 
   // Contracts
 

--- a/packages/sdk/src/rewards/types.ts
+++ b/packages/sdk/src/rewards/types.ts
@@ -1,16 +1,10 @@
 import type { Address, Log } from 'viem';
 import type { rewardsEventsAbi } from './abi/rewardsEvents.js';
-import type {
-  BackArgumentType,
-  BlockArgumentType,
-  LidoSDKCommonProps,
-} from '../core/types.js';
+import type { BackArgumentType, BlockArgumentType } from '../core/types.js';
 import type {
   TotalRewardEntity,
   TransferEventEntity,
 } from './subgraph/types.js';
-
-export type LidoSDKRewardsProps = LidoSDKCommonProps;
 
 export type GetRewardsOptions = {
   address: Address;

--- a/packages/sdk/src/shares/index.ts
+++ b/packages/sdk/src/shares/index.ts
@@ -1,2 +1,2 @@
 export { LidoSDKShares } from './shares.js';
-export type { LidoSDKSharesProps, SharesTransferProps } from './types.js';
+export type { SharesTransferProps } from './types.js';

--- a/packages/sdk/src/shares/shares.ts
+++ b/packages/sdk/src/shares/shares.ts
@@ -9,28 +9,17 @@ import {
 
 import { Logger, Cache, ErrorHandler } from '../common/decorators/index.js';
 import { LIDO_CONTRACT_NAMES, NOOP } from '../common/constants.js';
-import { LidoSDKCore, TransactionResult } from '../core/index.js';
-import { version } from '../version.js';
-import {
-  LidoSDKSharesProps,
-  SharesTotalSupplyResult,
-  SharesTransferProps,
-} from './types.js';
+import { TransactionResult } from '../core/index.js';
+
+import { SharesTotalSupplyResult, SharesTransferProps } from './types.js';
 import { stethSharesAbi } from './abi/steth-shares-abi.js';
 import { parseValue } from '../common/utils/parse-value.js';
 import { EtherValue, NoCallback } from '../core/types.js';
 import { calcShareRate } from '../rewards/utils.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
-export class LidoSDKShares {
+export class LidoSDKShares extends LidoSDKModule {
   static readonly PRECISION = 10n ** 27n;
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKSharesProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
-  }
 
   /// Contract
 

--- a/packages/sdk/src/shares/types.ts
+++ b/packages/sdk/src/shares/types.ts
@@ -1,11 +1,5 @@
 import type { Address } from 'viem';
-import type {
-  CommonTransactionProps,
-  EtherValue,
-  LidoSDKCommonProps,
-} from '../core/types.js';
-
-export type LidoSDKSharesProps = LidoSDKCommonProps;
+import type { CommonTransactionProps, EtherValue } from '../core/types.js';
 
 export type SharesTransferProps = CommonTransactionProps & {
   from?: Address;

--- a/packages/sdk/src/stake/stake.ts
+++ b/packages/sdk/src/stake/stake.ts
@@ -9,7 +9,6 @@ import type {
 } from 'viem';
 
 import {
-  LidoSDKCore,
   type TransactionResult,
   type PopulatedTransaction,
   TransactionOptions,
@@ -23,27 +22,17 @@ import {
   GAS_TRANSACTION_RATIO_PRECISION,
 } from '../common/constants.js';
 import { parseValue } from '../common/utils/parse-value.js';
-import { version } from '../version.js';
 
 import { StethAbi } from './abi/steth.js';
 import type {
-  LidoSDKStakeProps,
   StakeProps,
   StakeEncodeDataProps,
   StakeInnerProps,
   StakeLimitResult,
 } from './types.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
-export class LidoSDKStake {
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKStakeProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
-  }
-
+export class LidoSDKStake extends LidoSDKModule {
   // Contracts
 
   @Logger('Contracts:')

--- a/packages/sdk/src/stake/types.ts
+++ b/packages/sdk/src/stake/types.ts
@@ -1,8 +1,6 @@
 import { type Address, type Hash, type TransactionReceipt } from 'viem';
-import { CommonTransactionProps, LidoSDKCommonProps } from '../core/types.js';
+import { CommonTransactionProps } from '../core/types.js';
 import { EtherValue } from '../core/types.js';
-
-export type LidoSDKStakeProps = LidoSDKCommonProps;
 
 export type StakeProps = CommonTransactionProps & {
   value: EtherValue;

--- a/packages/sdk/src/statistics/apr.ts
+++ b/packages/sdk/src/statistics/apr.ts
@@ -1,20 +1,15 @@
-import { LidoSDKCore } from '../core/index.js';
 import { LidoSDKEvents } from '../events/index.js';
 import { Logger, ErrorHandler } from '../common/decorators/index.js';
-import { version } from '../version.js';
 
-import type { LidoSDKStatisticsProps } from './types.js';
 import { ERROR_CODE, invariant } from '../common/utils/sdk-error.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
+import { LidoSDKCommonProps } from '../core/types.js';
 
-export class LidoSDKApr {
-  readonly core: LidoSDKCore;
+export class LidoSDKApr extends LidoSDKModule {
   readonly events: LidoSDKEvents;
 
-  constructor(props: LidoSDKStatisticsProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
+  constructor(props: LidoSDKCommonProps) {
+    super(props);
 
     this.events = new LidoSDKEvents({ ...props, core: this.core });
   }

--- a/packages/sdk/src/statistics/index.ts
+++ b/packages/sdk/src/statistics/index.ts
@@ -1,3 +1,2 @@
 export { LidoSDKStatistics } from './statistics.js';
 export { LidoSDKApr } from './apr.js';
-export type { LidoSDKStatisticsProps } from './types.js';

--- a/packages/sdk/src/statistics/statistics.ts
+++ b/packages/sdk/src/statistics/statistics.ts
@@ -1,18 +1,13 @@
-import { LidoSDKCore } from '../core/index.js';
-import { version } from '../version.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
+import { LidoSDKCommonProps } from '../core/types.js';
 
 import { LidoSDKApr } from './apr.js';
-import type { LidoSDKStatisticsProps } from './types.js';
 
-export class LidoSDKStatistics {
-  readonly core: LidoSDKCore;
+export class LidoSDKStatistics extends LidoSDKModule {
   readonly apr: LidoSDKApr;
 
-  constructor(props: LidoSDKStatisticsProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
+  constructor(props: LidoSDKCommonProps) {
+    super(props);
 
     this.apr = new LidoSDKApr({ ...props, core: this.core });
   }

--- a/packages/sdk/src/statistics/types.ts
+++ b/packages/sdk/src/statistics/types.ts
@@ -1,3 +1,0 @@
-import { type LidoSDKCommonProps } from '../core/types.js';
-
-export type LidoSDKStatisticsProps = LidoSDKCommonProps;

--- a/packages/sdk/src/unsteth/index.ts
+++ b/packages/sdk/src/unsteth/index.ts
@@ -1,6 +1,5 @@
 export { LidoSDKUnstETH } from './unsteth.js';
 export {
-  type LidoSDKUnstETHProps,
   type UnstethNFT,
   type UnstethTransferProps,
   type UnstethApproveAllProps,

--- a/packages/sdk/src/unsteth/types.ts
+++ b/packages/sdk/src/unsteth/types.ts
@@ -1,15 +1,6 @@
 import { type Hash, type Address, type ContractFunctionResult } from 'viem';
-import LidoSDKCore from '../core/core.js';
-import {
-  TransactionCallback,
-  type LidoSDKCoreProps,
-  CommonTransactionProps,
-} from '../core/types.js';
+import { TransactionCallback, CommonTransactionProps } from '../core/types.js';
 import { type unstethAbi } from './abi/unsteth-abi.js';
-
-export type LidoSDKUnstETHProps = {
-  core?: LidoSDKCore;
-} & LidoSDKCoreProps;
 
 export type UnstethNFTstatus = ContractFunctionResult<
   typeof unstethAbi,

--- a/packages/sdk/src/unsteth/unsteth.ts
+++ b/packages/sdk/src/unsteth/unsteth.ts
@@ -1,17 +1,12 @@
-import {
-  CommonTransactionProps,
-  LidoSDKCore,
-  TransactionResult,
-} from '../core/index.js';
+import { CommonTransactionProps, TransactionResult } from '../core/index.js';
 import { Logger, Cache, ErrorHandler } from '../common/decorators/index.js';
-import { version } from '../version.js';
+
 import type {
   UnstethNFT,
   UnstethApproveAllProps,
   UnstethApproveProps,
   UnstethApprovedForProps,
   UnstethIsApprovedForAllProps,
-  LidoSDKUnstETHProps,
   ParsedProps,
   SafeTransferFromArguments,
   UnstethTransferProps,
@@ -26,18 +21,10 @@ import {
 } from 'viem';
 import { unstethAbi } from './abi/unsteth-abi.js';
 import { LIDO_CONTRACT_NAMES, NOOP } from '../common/constants.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 // TODO helpers simulate&populate
-export class LidoSDKUnstETH {
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKUnstETHProps) {
-    const { core, ...rest } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(rest, version);
-  }
-
+export class LidoSDKUnstETH extends LidoSDKModule {
   // Contract
 
   @Logger('Contracts:')

--- a/packages/sdk/src/withdraw/bus-module.ts
+++ b/packages/sdk/src/withdraw/bus-module.ts
@@ -1,11 +1,13 @@
+import { LidoSDKCacheable } from '../common/class-primitives/cacheable.js';
 import { type Bus } from './bus.js';
 import { type LidoSDKWithdrawModuleProps } from './types.js';
 
-export class BusModule {
+export class BusModule extends LidoSDKCacheable {
   protected readonly bus: Bus;
   protected version: string | undefined;
 
   constructor(props: LidoSDKWithdrawModuleProps) {
+    super();
     this.bus = props.bus;
     this.version = props.version;
   }

--- a/packages/sdk/src/withdraw/bus.ts
+++ b/packages/sdk/src/withdraw/bus.ts
@@ -1,5 +1,3 @@
-import { LidoSDKCore } from '../core/index.js';
-
 import { LidoSDKWithdrawContract } from './withdraw-contract.js';
 import { LidoSDKWithdrawViews } from './withdraw-views.js';
 import { LidoSDKWithdrawRequestsInfo } from './withdraw-requests-info.js';
@@ -8,31 +6,17 @@ import {
   LidoSDKWithdrawRequest,
   LidoSDKWithdrawApprove,
 } from './request/index.js';
-import { type LidoSDKWithdrawProps } from './types.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
-export class Bus {
+export class Bus extends LidoSDKModule {
   private version: string | undefined;
 
-  private coreInstance: LidoSDKCore;
   private contractInstance: LidoSDKWithdrawContract | undefined;
   private viewsInstance: LidoSDKWithdrawViews | undefined;
   private requestsInfoInstance: LidoSDKWithdrawRequestsInfo | undefined;
   private approvalInstance: LidoSDKWithdrawApprove | undefined;
   private claimInstance: LidoSDKWithdrawClaim | undefined;
   private requestInstance: LidoSDKWithdrawRequest | undefined;
-
-  constructor(props: LidoSDKWithdrawProps, version?: string) {
-    this.version = version;
-
-    if (props.core) this.coreInstance = props.core;
-    else this.coreInstance = new LidoSDKCore(props, this.version);
-  }
-
-  // core
-
-  get core(): LidoSDKCore {
-    return this.coreInstance;
-  }
 
   // Contract
 

--- a/packages/sdk/src/withdraw/request/approve.ts
+++ b/packages/sdk/src/withdraw/request/approve.ts
@@ -9,22 +9,15 @@ import { NOOP } from '../../common/constants.js';
 import { parseValue } from '../../common/utils/parse-value.js';
 import { Logger, Cache, ErrorHandler } from '../../common/decorators/index.js';
 
-import { Bus } from '../bus.js';
-import { LidoSDKWithdrawModuleProps } from '../types.js';
 import type {
   CheckAllowanceProps,
   CheckAllowanceResult,
   GetAllowanceProps,
   WithdrawApproveProps,
 } from './types.js';
+import { BusModule } from '../bus-module.js';
 
-export class LidoSDKWithdrawApprove {
-  private readonly bus: Bus;
-
-  constructor(props: LidoSDKWithdrawModuleProps) {
-    this.bus = props.bus;
-  }
-
+export class LidoSDKWithdrawApprove extends BusModule {
   @Logger('Call:')
   @ErrorHandler()
   public async approve(

--- a/packages/sdk/src/withdraw/types.ts
+++ b/packages/sdk/src/withdraw/types.ts
@@ -1,9 +1,5 @@
 import type { Address } from 'viem';
-
-import type { LidoSDKCommonProps } from '../core/types.js';
 import type { Bus } from './bus.js';
-
-export type LidoSDKWithdrawProps = LidoSDKCommonProps;
 
 export type LidoSDKWithdrawModuleProps = { bus: Bus; version?: string };
 

--- a/packages/sdk/src/withdraw/withdraw.ts
+++ b/packages/sdk/src/withdraw/withdraw.ts
@@ -1,10 +1,3 @@
-import { version } from '../version.js';
-
 import { Bus } from './bus.js';
-import { LidoSDKWithdrawProps } from './types.js';
 
-export class LidoSDKWithdraw extends Bus {
-  constructor(props: LidoSDKWithdrawProps) {
-    super(props, version);
-  }
-}
+export class LidoSDKWithdraw extends Bus {}

--- a/packages/sdk/src/wrap/index.ts
+++ b/packages/sdk/src/wrap/index.ts
@@ -1,6 +1,2 @@
 export { LidoSDKWrap } from './wrap.js';
-export {
-  type LidoSDKWrapProps,
-  type WrapProps,
-  type WrapPropsWithoutCallback,
-} from './types.js';
+export type { WrapProps, WrapPropsWithoutCallback } from './types.js';

--- a/packages/sdk/src/wrap/types.ts
+++ b/packages/sdk/src/wrap/types.ts
@@ -1,11 +1,5 @@
 import type { FormattedTransactionRequest } from 'viem';
-import type {
-  LidoSDKCommonProps,
-  EtherValue,
-  CommonTransactionProps,
-} from '../core/types.js';
-
-export type LidoSDKWrapProps = LidoSDKCommonProps;
+import type { EtherValue, CommonTransactionProps } from '../core/types.js';
 
 export type WrapProps = CommonTransactionProps & {
   value: EtherValue;

--- a/packages/sdk/src/wrap/wrap.ts
+++ b/packages/sdk/src/wrap/wrap.ts
@@ -9,7 +9,6 @@ import {
   type WriteContractParameters,
 } from 'viem';
 
-import { LidoSDKCore } from '../core/index.js';
 import { LIDO_CONTRACT_NAMES, NOOP } from '../common/constants.js';
 import {
   EtherValue,
@@ -18,10 +17,8 @@ import {
 } from '../core/types.js';
 import { parseValue } from '../common/utils/parse-value.js';
 import { Logger, Cache, ErrorHandler } from '../common/decorators/index.js';
-import { version } from '../version.js';
 
 import type {
-  LidoSDKWrapProps,
   WrapProps,
   WrapInnerProps,
   WrapPropsWithoutCallback,
@@ -30,17 +27,9 @@ import type {
 import { abi } from './abi/wsteth.js';
 import { stethPartialAbi } from './abi/steth-partial.js';
 import { ERROR_CODE } from '../common/utils/sdk-error.js';
+import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
-export class LidoSDKWrap {
-  readonly core: LidoSDKCore;
-
-  constructor(props: LidoSDKWrapProps) {
-    const { core } = props;
-
-    if (core) this.core = core;
-    else this.core = new LidoSDKCore(props, version);
-  }
-
+export class LidoSDKWrap extends LidoSDKModule {
   // Contracts
 
   @Logger('Contracts:')


### PR DESCRIPTION
### Description

- switch over to per instance cache
- refactor out boilerplate 

### Testing notes

Bug where steth and wsteth had cache collusion and showed same data on balance methods is fixed and checked locally. But should be checked.

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [x]   Created/updated README.md.

