### PR TITLE
fix: erc20 cache collusion

### DIFF
--- a/packages/sdk/src/erc20/erc20.ts
+++ b/packages/sdk/src/erc20/erc20.ts
@@ -19,7 +19,6 @@ import {
   PublicClient,
   WalletClient,
   encodeFunctionData,
-  getContract,
 } from 'viem';
 import { NOOP, PERMIT_MESSAGE_TYPES } from '../common/constants.js';
 import { parseValue } from '../common/utils/parse-value.js';
@@ -45,19 +44,9 @@ export abstract class AbstractLidoSDKErc20 {
 
   public abstract contractAddress(): Promise<Address>;
 
-  @Logger('Contracts:')
-  @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressWstETH'])
-  public async getContract(): Promise<
+  public abstract getContract(): Promise<
     GetContractReturnType<typeof erc20abi, PublicClient, WalletClient>
-  > {
-    const address = await this.contractAddress();
-    return getContract({
-      address,
-      abi: erc20abi,
-      publicClient: this.core.rpcProvider,
-      walletClient: this.core.web3Provider,
-    });
-  }
+  >;
 
   // Balance
 

--- a/packages/sdk/src/erc20/steth.ts
+++ b/packages/sdk/src/erc20/steth.ts
@@ -1,8 +1,15 @@
-import { Address } from 'viem';
+import {
+  Address,
+  GetContractReturnType,
+  PublicClient,
+  WalletClient,
+  getContract as getContractViem,
+} from 'viem';
 import { AbstractLidoSDKErc20 } from './erc20.js';
 import { Logger, Cache } from '../common/decorators/index.js';
 import { LIDO_CONTRACT_NAMES } from '../common/constants.js';
 import invariant from 'tiny-invariant';
+import { erc20abi } from './abi/erc20abi.js';
 
 export class LidoSDKstETH extends AbstractLidoSDKErc20 {
   @Logger('Contracts:')
@@ -10,5 +17,19 @@ export class LidoSDKstETH extends AbstractLidoSDKErc20 {
   public override contractAddress(): Promise<Address> {
     invariant(this.core.chain, 'Chain is not defined');
     return this.core.getContractAddress(LIDO_CONTRACT_NAMES.lido);
+  }
+
+  @Logger('Contracts:')
+  @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressStETH'])
+  public override async getContract(): Promise<
+    GetContractReturnType<typeof erc20abi, PublicClient, WalletClient>
+  > {
+    const address = await this.contractAddress();
+    return getContractViem({
+      address,
+      abi: erc20abi,
+      publicClient: this.core.rpcProvider,
+      walletClient: this.core.web3Provider,
+    });
   }
 }

--- a/packages/sdk/src/erc20/wsteth.ts
+++ b/packages/sdk/src/erc20/wsteth.ts
@@ -1,8 +1,15 @@
-import { Address } from 'viem';
+import {
+  Address,
+  GetContractReturnType,
+  PublicClient,
+  WalletClient,
+  getContract as getContractViem,
+} from 'viem';
 import { AbstractLidoSDKErc20 } from './erc20.js';
 import { Logger, Cache } from '../common/decorators/index.js';
 import { LIDO_CONTRACT_NAMES } from '../common/constants.js';
 import invariant from 'tiny-invariant';
+import { erc20abi } from './abi/erc20abi.js';
 
 export class LidoSDKwstETH extends AbstractLidoSDKErc20 {
   @Logger('Contracts:')
@@ -24,5 +31,19 @@ export class LidoSDKwstETH extends AbstractLidoSDKErc20 {
       chainId: BigInt(this.core.chain.id),
       verifyingContract: await this.contractAddress(),
     };
+  }
+
+  @Logger('Contracts:')
+  @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressWstETH'])
+  public override async getContract(): Promise<
+    GetContractReturnType<typeof erc20abi, PublicClient, WalletClient>
+  > {
+    const address = await this.contractAddress();
+    return getContractViem({
+      address,
+      abi: erc20abi,
+      publicClient: this.core.rpcProvider,
+      walletClient: this.core.web3Provider,
+    });
   }
 }


### PR DESCRIPTION
### Description

Hotfix for v2 fixing cache collusion bug in token modules

### Code review notes

Fixed in a different way than in v3.

### Testing notes

Test that steth and wsteth modules don't interfere with each other 

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

