### PR TITLE
[unit tests] Stats

### DIFF
--- a/packages/sdk/src/events/__tests__/events.test.ts
+++ b/packages/sdk/src/events/__tests__/events.test.ts
@@ -8,7 +8,7 @@ import { LIDO_CONTRACT_NAMES } from '../../index.js';
 import { expectRebaseEvent } from '../../../tests/utils/expect/expect-rebase-event.js';
 
 describe('LidoSDKEvents', () => {
-  const { stethEvents, core } = useEvents();
+  const { stethEvents, core } = useEvents({ useDirectRpc: true });
   let lidoAddress = '';
 
   beforeAll(async () => {

--- a/packages/sdk/src/statistics/__tests__/stats.test.ts
+++ b/packages/sdk/src/statistics/__tests__/stats.test.ts
@@ -1,0 +1,96 @@
+import { describe, test, expect } from '@jest/globals';
+import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
+import { AprRebaseEvent, LidoSDKApr, LidoSDKStatistics } from '../../index.js';
+
+import { useStats } from '../../../tests/utils/fixtures/use-stats.js';
+
+const APR_SPEC: Array<[AprRebaseEvent, number]> = [
+  [
+    {
+      timeElapsed: 4608n,
+      preTotalShares: 380434172050725886214426n,
+      preTotalEther: 381568992239135809181277n,
+      postTotalShares: 380434280124073199943710n,
+      postTotalEther: 381570076199165808306368n,
+    },
+    1.7,
+  ],
+  [
+    {
+      preTotalEther: 381546767228440793115619n,
+      preTotalShares: 380431956104410024720267n,
+      postTotalEther: 381570076199165808306368n,
+      postTotalShares: 380434280124073199943710n,
+      timeElapsed: 96768n,
+    },
+    1.7,
+  ],
+  [
+    {
+      preTotalEther: 381525342519484532036668n,
+      preTotalShares: 380429818132108977600266n,
+      postTotalEther: 381570076199165808306368n,
+      postTotalShares: 380434280124073199943710n,
+      timeElapsed: 188928n,
+    },
+    1.7,
+  ],
+  [
+    {
+      postTotalEther: 9214558073511239726258077n,
+      postTotalShares: 8015162922459393384526309n,
+      preTotalEther: 9263068471084128020814862n,
+      preTotalShares: 8066681860242338824295513n,
+      timeElapsed: 950400n,
+    },
+    3.8,
+  ],
+  [
+    {
+      postTotalEther: 9214558073511239726258077n,
+      postTotalShares: 8015162922459393384526309n,
+      preTotalEther: 8394212555328852098606993n,
+      preTotalShares: 7381214257921691114069196n,
+      timeElapsed: 9244800n,
+    },
+    3.7,
+  ],
+  [
+    {
+      postTotalEther: 1117524237432571389949096n,
+      postTotalShares: 941217337772777324482426n,
+      preTotalEther: 411807460465253736065963n,
+      preTotalShares: 352884611916239405037988n,
+      timeElapsed: 12009600n,
+    },
+    4.5,
+  ],
+];
+
+describe('LidoSDKStats', () => {
+  const { apr } = useStats({ useDirectRpc: true });
+
+  test('is correct module', () => {
+    expectSDKModule(LidoSDKStatistics);
+    expectSDKModule(LidoSDKApr);
+    expect(apr).toBeInstanceOf(LidoSDKApr);
+  });
+
+  test('getLastApr', async () => {
+    const lastApr = await apr.getLastApr();
+    expect(typeof lastApr).toBe('number');
+    expect(lastApr).toBeGreaterThan(0);
+    expect(lastApr).toBeLessThan(40);
+  });
+
+  test.each([[1], [2], [3], [10]])('getSmaApr for %i days', async (days) => {
+    const lastApr = await apr.getSmaApr({ days });
+    expect(typeof lastApr).toBe('number');
+    expect(lastApr).toBeGreaterThan(0);
+    expect(lastApr).toBeLessThan(40);
+  });
+
+  test.each(APR_SPEC)('calculateAprFromRebaseEvent %#', (props, result) => {
+    expect(LidoSDKApr.calculateAprFromRebaseEvent(props)).toBe(result);
+  });
+});

--- a/packages/sdk/src/statistics/apr.ts
+++ b/packages/sdk/src/statistics/apr.ts
@@ -4,6 +4,7 @@ import { Logger, ErrorHandler } from '../common/decorators/index.js';
 import { ERROR_CODE, invariant } from '../common/utils/sdk-error.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 import { LidoSDKCommonProps } from '../core/types.js';
+import { AprRebaseEvent } from './types.js';
 
 export class LidoSDKApr extends LidoSDKModule {
   readonly events: LidoSDKEvents;
@@ -14,21 +15,13 @@ export class LidoSDKApr extends LidoSDKModule {
     this.events = new LidoSDKEvents({ ...props, core: this.core });
   }
 
-  public static calculateAprFromRebaseEvent(props: {
-    preTotalEther: bigint;
-    preTotalShares: bigint;
-    postTotalEther: bigint;
-    postTotalShares: bigint;
-    timeElapsed: bigint;
-  }): number {
-    const {
-      preTotalEther,
-      preTotalShares,
-      postTotalEther,
-      postTotalShares,
-      timeElapsed,
-    } = props;
-
+  public static calculateAprFromRebaseEvent({
+    preTotalEther,
+    preTotalShares,
+    postTotalEther,
+    postTotalShares,
+    timeElapsed,
+  }: AprRebaseEvent): number {
     const preShareRate = (preTotalEther * BigInt(10 ** 27)) / preTotalShares;
     const postShareRate = (postTotalEther * BigInt(10 ** 27)) / postTotalShares;
     const mulForPrecision = 1000;
@@ -39,6 +32,17 @@ export class LidoSDKApr extends LidoSDKModule {
         ((postShareRate - preShareRate) * BigInt(mulForPrecision))) /
       preShareRate /
       timeElapsed;
+
+    console.log([
+      {
+        preTotalEther,
+        preTotalShares,
+        postTotalEther,
+        postTotalShares,
+        timeElapsed,
+      },
+      (Number(userAPR) * 100) / mulForPrecision,
+    ]);
 
     return (Number(userAPR) * 100) / mulForPrecision;
   }

--- a/packages/sdk/src/statistics/apr.ts
+++ b/packages/sdk/src/statistics/apr.ts
@@ -4,7 +4,7 @@ import { Logger, ErrorHandler } from '../common/decorators/index.js';
 import { ERROR_CODE, invariant } from '../common/utils/sdk-error.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 import { LidoSDKCommonProps } from '../core/types.js';
-import { AprRebaseEvent } from './types.js';
+import type { AprRebaseEvent } from './types.js';
 
 export class LidoSDKApr extends LidoSDKModule {
   readonly events: LidoSDKEvents;
@@ -32,17 +32,6 @@ export class LidoSDKApr extends LidoSDKModule {
         ((postShareRate - preShareRate) * BigInt(mulForPrecision))) /
       preShareRate /
       timeElapsed;
-
-    console.log([
-      {
-        preTotalEther,
-        preTotalShares,
-        postTotalEther,
-        postTotalShares,
-        timeElapsed,
-      },
-      (Number(userAPR) * 100) / mulForPrecision,
-    ]);
 
     return (Number(userAPR) * 100) / mulForPrecision;
   }

--- a/packages/sdk/src/statistics/index.ts
+++ b/packages/sdk/src/statistics/index.ts
@@ -1,2 +1,3 @@
+export type { AprRebaseEvent } from './types.js';
 export { LidoSDKStatistics } from './statistics.js';
 export { LidoSDKApr } from './apr.js';

--- a/packages/sdk/src/statistics/types.ts
+++ b/packages/sdk/src/statistics/types.ts
@@ -1,0 +1,7 @@
+export type AprRebaseEvent = {
+  preTotalEther: bigint;
+  preTotalShares: bigint;
+  postTotalEther: bigint;
+  postTotalShares: bigint;
+  timeElapsed: bigint;
+};

--- a/packages/sdk/tests/utils/fixtures/use-core.ts
+++ b/packages/sdk/tests/utils/fixtures/use-core.ts
@@ -19,6 +19,21 @@ export const useRpcCore = () => {
   return cachedRpcCore;
 };
 
+let cachedDirectRpcCore: LidoSDKCore | null = null;
+
+export const useDirectRpcCore = () => {
+  const { chainId, rpcUrl } = useTestsEnvs();
+
+  if (!cachedDirectRpcCore) {
+    cachedDirectRpcCore = new LidoSDKCore({
+      chainId: chainId,
+      logMode: 'none',
+      rpcUrls: [rpcUrl],
+    });
+  }
+  return cachedDirectRpcCore;
+};
+
 let cachedWeb3Core: LidoSDKCore | null = null;
 
 export const useWeb3Core = () => {

--- a/packages/sdk/tests/utils/fixtures/use-events.ts
+++ b/packages/sdk/tests/utils/fixtures/use-events.ts
@@ -1,8 +1,12 @@
 import { LidoSDKEvents } from '../../../src/index.js';
-import { useRpcCore } from './use-core.js';
+import { useDirectRpcCore, useRpcCore } from './use-core.js';
 
-export const useEvents = () => {
-  const core = useRpcCore();
+type UseModuleOptions = {
+  useDirectRpc?: boolean;
+};
+
+export const useEvents = ({ useDirectRpc = false }: UseModuleOptions = {}) => {
+  const core = useDirectRpc ? useDirectRpcCore() : useRpcCore();
   const events = new LidoSDKEvents({ core });
   return events;
 };

--- a/packages/sdk/tests/utils/fixtures/use-stats.ts
+++ b/packages/sdk/tests/utils/fixtures/use-stats.ts
@@ -1,0 +1,12 @@
+import { LidoSDKStatistics } from '../../../src/index.js';
+import { useDirectRpcCore, useRpcCore } from './use-core.js';
+
+type UseModuleOptions = {
+  useDirectRpc?: boolean;
+};
+
+export const useStats = ({ useDirectRpc = false }: UseModuleOptions = {}) => {
+  const core = useDirectRpc ? useDirectRpcCore() : useRpcCore();
+  const stats = new LidoSDKStatistics({ core });
+  return stats;
+};

--- a/packages/sdk/tests/utils/fixtures/use-test-rpc-provider.ts
+++ b/packages/sdk/tests/utils/fixtures/use-test-rpc-provider.ts
@@ -2,6 +2,7 @@ import type { EthereumProvider } from 'ganache';
 import {
   createTestClient,
   custom,
+  http,
   publicActions,
   PublicClient,
   TestClient,
@@ -21,6 +22,8 @@ export const useTestRpcProvider = () => {
   const ganacheProvider = (globalThis as any)
     .__ganache_provider__ as EthereumProvider;
 
+  const localhost = http('http://localhost:3333');
+
   const testClient = createTestClient({
     mode: 'ganache',
     transport: custom({
@@ -28,7 +31,7 @@ export const useTestRpcProvider = () => {
         if (args.method === 'eth_estimateGas') {
           delete args.params[0].gas;
         }
-        return ganacheProvider.request(args);
+        return localhost({}).request(args);
       },
     }),
     name: 'testClient',

--- a/packages/sdk/tests/utils/fixtures/use-test-rpc-provider.ts
+++ b/packages/sdk/tests/utils/fixtures/use-test-rpc-provider.ts
@@ -2,7 +2,6 @@ import type { EthereumProvider } from 'ganache';
 import {
   createTestClient,
   custom,
-  http,
   publicActions,
   PublicClient,
   TestClient,
@@ -22,8 +21,6 @@ export const useTestRpcProvider = () => {
   const ganacheProvider = (globalThis as any)
     .__ganache_provider__ as EthereumProvider;
 
-  const localhost = http('http://localhost:3333');
-
   const testClient = createTestClient({
     mode: 'ganache',
     transport: custom({
@@ -31,7 +28,7 @@ export const useTestRpcProvider = () => {
         if (args.method === 'eth_estimateGas') {
           delete args.params[0].gas;
         }
-        return localhost({}).request(args);
+        return ganacheProvider.request(args);
       },
     }),
     name: 'testClient',


### PR DESCRIPTION
### Description

- events and stats tests now use RPC directly because ganache is buggy for `eth_getLogs`
- stats tests
- minor type improvement for stats


### Code review notes

Seems we will need to move from `ganache` to `hardhat` because it's the only maintained fork cli. 

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [x]  Created/updated README.md.

