### PR TITLE
Meaningful transaction return

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           NODE_NO_BUILD_DYNAMICS: true
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./playground/out
 
@@ -78,4 +78,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -92,24 +92,24 @@ All examples and usage instructions can be found in the [Docs SDK package](packa
 const lidoSDK = new LidoSDK({
   chainId: 5,
   rpcUrls: ['https://eth-goerli.alchemyapi.io/v2/{ALCHEMY_API_KEY}'],
+  web3Provider: provider,
 });
-
-// Define default web3 provider in sdk (window.ethereum) if web3Provider is not defined in constructor
-lidoSDK.core.defineWeb3Provider();
 
 // Views
 const balanceETH = await lidoSDK.core.balanceETH(address);
 
 // Calls
-const stakeResult = await lidoSDK.stake.stakeEth({
+const stakeTx = await lidoSDK.stake.stakeEth({
   value,
   callback,
   referralAddress,
   account,
 });
 
+// relevant results are returned with transaction
+const { stethReceived, sharesReceived } = stakeTx.result;
+
 console.log(balanceETH.toString(), 'ETH balance');
-console.log(stakeResult, 'stake result');
 ```
 
 ## Migration

--- a/packages/sdk/jest.config.ts
+++ b/packages/sdk/jest.config.ts
@@ -3,10 +3,11 @@ import type { JestConfigWithTsJest } from 'ts-jest';
 const jestConfig: JestConfigWithTsJest = {
   displayName: 'LidoSDK tests',
   testEnvironment: 'node',
+  // fix for leftover handles when running locally on macos
+  detectOpenHandles: true,
+  forceExit: true,
   preset: 'ts-jest',
   verbose: true,
-
-  detectOpenHandles: true,
   extensionsToTreatAsEsm: ['.ts'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
@@ -22,6 +23,7 @@ const jestConfig: JestConfigWithTsJest = {
   },
   maxWorkers: 1,
   globalSetup: '<rootDir>/tests/global-setup.cjs',
+  globalTeardown: '<rootDir>/tests/global-teardown.cjs',
   testTimeout: 300_000,
 };
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -145,7 +145,7 @@
     "@ethersproject/bytes": "^5.7.0",
     "graphql": "^16.8.1",
     "graphql-request": "^6.1.0",
-    "viem": "^1.18.8"
+    "viem": "^2.0.6"
   },
   "devDependencies": {
     "@jest/globals": "^29.7.0",

--- a/packages/sdk/src/core/__tests__/core-wallet.test.ts
+++ b/packages/sdk/src/core/__tests__/core-wallet.test.ts
@@ -109,7 +109,7 @@ describe('Core Wallet Tests', () => {
     const contract = getContract({
       abi: permitAbi,
       address: contractAddress,
-      publicClient: web3Core.rpcProvider,
+      client: web3Core.rpcProvider,
     });
 
     await contract.simulate.permit([

--- a/packages/sdk/src/core/core.ts
+++ b/packages/sdk/src/core/core.ts
@@ -469,7 +469,7 @@ export default class LidoSDKCore extends LidoSDKCacheable {
   public async performTransaction<TDecodedResult = undefined>(
     props: PerformTransactionOptions<TDecodedResult>,
   ): Promise<TransactionResult<TDecodedResult>> {
-    //
+    // this guards against not having web3Provider
     this.useWeb3Provider();
     const {
       callback = NOOP,

--- a/packages/sdk/src/core/core.ts
+++ b/packages/sdk/src/core/core.ts
@@ -533,7 +533,7 @@ export default class LidoSDKCore extends LidoSDKCacheable {
 
     if (isContract) {
       callback({ stage: TransactionCallbackStage.MULTISIG_DONE });
-      return { hash: hash };
+      return { hash };
     }
 
     callback({
@@ -543,7 +543,7 @@ export default class LidoSDKCore extends LidoSDKCacheable {
 
     const receipt = await withSDKError(
       this.rpcProvider.waitForTransactionReceipt({
-        hash: hash,
+        hash,
         timeout: 120_000,
         ...waitForTransactionReceiptParameters,
       }),

--- a/packages/sdk/src/core/core.ts
+++ b/packages/sdk/src/core/core.ts
@@ -13,7 +13,7 @@ import {
   custom,
   getContract,
   maxUint256,
-  Account,
+  JsonRpcAccount,
 } from 'viem';
 import {
   ERROR_CODE,
@@ -177,14 +177,12 @@ export default class LidoSDKCore extends LidoSDKCacheable {
   @Cache(30 * 60 * 1000, ['chain.id', 'contractAddressLidoLocator'])
   public getContractLidoLocator(): GetContractReturnType<
     typeof LidoLocatorAbi,
-    PublicClient,
-    WalletClient
+    PublicClient
   > {
     return getContract({
       address: this.contractAddressLidoLocator(),
       abi: LidoLocatorAbi,
-      publicClient: this.rpcProvider,
-      walletClient: this.web3Provider,
+      client: this.rpcProvider,
     });
   }
 
@@ -196,7 +194,7 @@ export default class LidoSDKCore extends LidoSDKCacheable {
     return getContract({
       address,
       abi: wqAbi,
-      publicClient: this.rpcProvider,
+      client: this.rpcProvider,
     });
   }
 
@@ -254,8 +252,7 @@ export default class LidoSDKCore extends LidoSDKCacheable {
     const contract = getContract({
       address: tokenAddress,
       abi: permitAbi,
-      publicClient: this.rpcProvider,
-      walletClient: this.web3Provider,
+      client: this.rpcProvider,
     });
 
     let domain = {
@@ -331,11 +328,13 @@ export default class LidoSDKCore extends LidoSDKCacheable {
   }
 
   @Logger('Utils:')
-  public async useAccount(accountValue?: AccountValue): Promise<Account> {
+  public async useAccount(
+    accountValue?: AccountValue,
+  ): Promise<JsonRpcAccount> {
     if (accountValue) {
       if (typeof accountValue === 'string')
         return { address: accountValue, type: 'json-rpc' };
-      else return accountValue;
+      else return accountValue as JsonRpcAccount;
     }
     if (this.web3Provider) {
       if (!this.web3Provider.account) {
@@ -350,7 +349,7 @@ export default class LidoSDKCore extends LidoSDKCacheable {
         );
         this.web3Provider.account = { address: account, type: 'json-rpc' };
       }
-      return this.web3Provider.account;
+      return this.web3Provider.account as unknown as JsonRpcAccount;
     }
     invariantArgument(false, 'No account or web3Provider is available');
   }

--- a/packages/sdk/src/core/types.ts
+++ b/packages/sdk/src/core/types.ts
@@ -72,11 +72,21 @@ export type PerformTransactionSendTransaction = (
   override: TransactionOptions,
 ) => Promise<Hash>;
 
-export type PerformTransactionOptions = CommonTransactionProps & {
-  getGasLimit: PerformTransactionGasLimit;
-  sendTransaction: PerformTransactionSendTransaction;
-  waitForTransactionReceiptParameters?: WaitForTransactionReceiptParameters;
-};
+export type PerformTransactionDecodeResult<TDecodedResult> = (
+  receipt: TransactionReceipt,
+) => Promise<TDecodedResult>;
+
+type PerformTransactionOptionsDecodePartial<TDecodedResult> =
+  TDecodedResult extends undefined
+    ? { decodeResult?: undefined }
+    : { decodeResult: PerformTransactionDecodeResult<TDecodedResult> };
+
+export type PerformTransactionOptions<TDecodedResult> =
+  CommonTransactionProps & {
+    getGasLimit: PerformTransactionGasLimit;
+    sendTransaction: PerformTransactionSendTransaction;
+    waitForTransactionReceiptParameters?: WaitForTransactionReceiptParameters;
+  } & PerformTransactionOptionsDecodePartial<TDecodedResult>;
 
 export type TransactionOptions = {
   account: AccountValue;
@@ -87,10 +97,11 @@ export type TransactionOptions = {
   nonce?: number;
 };
 
-export type TransactionResult = {
+export type TransactionResult<TDecodedResult = undefined> = {
   hash: Hash;
   receipt?: TransactionReceipt;
   confirmations?: bigint;
+  result?: TDecodedResult;
 };
 
 export type PopulatedTransaction = Omit<FormattedTransactionRequest, 'type'>;

--- a/packages/sdk/src/erc20/erc20.ts
+++ b/packages/sdk/src/erc20/erc20.ts
@@ -12,7 +12,6 @@ import {
   type Address,
   type GetContractReturnType,
   type Hash,
-  type PublicClient,
   type WalletClient,
   encodeFunctionData,
   getContract,
@@ -37,14 +36,16 @@ export abstract class AbstractLidoSDKErc20 extends LidoSDKModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['core.chain.id'])
   public async getContract(): Promise<
-    GetContractReturnType<typeof erc20abi, PublicClient, WalletClient>
+    GetContractReturnType<typeof erc20abi, WalletClient>
   > {
     const address = await this.contractAddress();
     return getContract({
       address,
       abi: erc20abi,
-      publicClient: this.core.rpcProvider,
-      walletClient: this.core.web3Provider,
+      client: {
+        public: this.core.rpcProvider,
+        wallet: this.core.web3Provider as WalletClient,
+      },
     });
   }
 

--- a/packages/sdk/src/erc20/types.ts
+++ b/packages/sdk/src/erc20/types.ts
@@ -1,4 +1,4 @@
-import type { Account, Address } from 'viem';
+import type { Address, JsonRpcAccount } from 'viem';
 import { type EtherValue } from '../core/index.js';
 import {
   AccountValue,
@@ -11,7 +11,7 @@ export type InnerTransactionProps = Required<CommonTransactionProps>;
 export type ParsedTransactionProps<TProps extends CommonTransactionProps> =
   Omit<TProps, 'callback'> & {
     callback: NonNullable<TProps['callback']>;
-    account: Account;
+    account: JsonRpcAccount;
   } & (TProps extends { amount: EtherValue } ? { amount: bigint } : object);
 
 export type TransferProps = {

--- a/packages/sdk/src/events/steth-events.ts
+++ b/packages/sdk/src/events/steth-events.ts
@@ -1,10 +1,5 @@
 import { getContract } from 'viem';
-import type {
-  Address,
-  GetContractReturnType,
-  PublicClient,
-  WalletClient,
-} from 'viem';
+import type { Address, GetContractReturnType, PublicClient } from 'viem';
 
 import { Logger, Cache, ErrorHandler } from '../common/decorators/index.js';
 import { LIDO_CONTRACT_NAMES } from '../common/constants.js';
@@ -41,14 +36,14 @@ export class LidoSDKStethEvents extends LidoSDKModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressStETH'])
   private async getContractStETH(): Promise<
-    GetContractReturnType<typeof StethEventsAbi, PublicClient, WalletClient>
+    GetContractReturnType<typeof StethEventsAbi, PublicClient>
   > {
     const address = await this.contractAddressStETH();
 
     return getContract({
       address,
       abi: StethEventsAbi,
-      publicClient: this.core.rpcProvider,
+      client: this.core.rpcProvider,
     });
   }
 

--- a/packages/sdk/src/rewards/rewards.ts
+++ b/packages/sdk/src/rewards/rewards.ts
@@ -79,7 +79,7 @@ export class LidoSDKRewards extends LidoSDKModule {
     return getContract({
       address,
       abi: rewardsEventsAbi,
-      publicClient: this.core.rpcProvider,
+      client: this.core.rpcProvider,
     });
   }
 

--- a/packages/sdk/src/shares/shares.ts
+++ b/packages/sdk/src/shares/shares.ts
@@ -1,7 +1,6 @@
 import {
   type GetContractReturnType,
   type Address,
-  type PublicClient,
   type WalletClient,
   getContract,
   encodeFunctionData,
@@ -37,15 +36,17 @@ export class LidoSDKShares extends LidoSDKModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressStETH'])
   public async getContractStETHshares(): Promise<
-    GetContractReturnType<typeof stethSharesAbi, PublicClient, WalletClient>
+    GetContractReturnType<typeof stethSharesAbi, WalletClient>
   > {
     const address = await this.contractAddressStETH();
 
     return getContract({
       address,
       abi: stethSharesAbi,
-      publicClient: this.core.rpcProvider,
-      walletClient: this.core.web3Provider,
+      client: {
+        public: this.core.rpcProvider,
+        wallet: this.core.web3Provider as WalletClient,
+      },
     });
   }
 

--- a/packages/sdk/src/stake/__tests__/stake-wallet.test.ts
+++ b/packages/sdk/src/stake/__tests__/stake-wallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, jest } from '@jest/globals';
+import { describe, jest, expect } from '@jest/globals';
 import { useStake } from '../../../tests/utils/fixtures/use-stake.js';
 import {
   SPENDING_TIMEOUT,
@@ -7,15 +7,18 @@ import {
 import { expectTxCallback } from '../../../tests/utils/expect/expect-tx-callback.js';
 import { expectAlmostEqualBn } from '../../../tests/utils/expect/expect-bn.js';
 import { useSteth } from '../../../tests/utils/fixtures/use-steth.js';
+import { useShares } from '../../../tests/utils/fixtures/use-shares.js';
 
 describe('LidoSDKStake wallet methods', () => {
   const stake = useStake();
   const steth = useSteth();
+  const shares = useShares();
   testSpending(
     'can stake',
     async () => {
       const stakeValue = 100n;
       const balanceBefore = await steth.balance();
+      const balanceSharesBefore = await shares.balance();
       const mockTxCallback = jest.fn();
       const tx = await stake.stakeEth({
         value: stakeValue,
@@ -23,8 +26,16 @@ describe('LidoSDKStake wallet methods', () => {
       });
       expectTxCallback(mockTxCallback, tx);
       const balanceAfter = await steth.balance();
+      const balanceSharesAfter = await shares.balance();
+      const balanceDiff = balanceAfter - balanceBefore;
+      const balanceSharesDiff = balanceSharesAfter - balanceSharesBefore;
       // due to protocol rounding error this can happen
-      expectAlmostEqualBn(balanceAfter - balanceBefore, stakeValue);
+      expectAlmostEqualBn(balanceDiff, stakeValue);
+      expect(tx.result).toBeDefined();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const result = tx.result!;
+      expectAlmostEqualBn(result.stethReceived, balanceDiff);
+      expect(result.sharesReceived).toEqual(balanceSharesDiff);
     },
     SPENDING_TIMEOUT,
   );

--- a/packages/sdk/src/stake/abi/steth.ts
+++ b/packages/sdk/src/stake/abi/steth.ts
@@ -695,3 +695,27 @@ export const StethAbi = [
     type: 'event',
   },
 ] as const;
+
+// smaller ABI for less overhead when parsing submit events
+export const StethEventsPartialAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'sharesValue', type: 'uint256' },
+    ],
+    name: 'TransferShares',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'value', type: 'uint256' },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+] as const;

--- a/packages/sdk/src/stake/types.ts
+++ b/packages/sdk/src/stake/types.ts
@@ -1,4 +1,4 @@
-import type { Account, Address, Hash, TransactionReceipt } from 'viem';
+import type { Account, Address } from 'viem';
 import { CommonTransactionProps } from '../core/types.js';
 import { EtherValue } from '../core/types.js';
 
@@ -14,9 +14,8 @@ export type StakeInnerProps = CommonTransactionProps & {
 };
 
 export type StakeResult = {
-  hash: Hash;
-  receipt?: TransactionReceipt;
-  confirmations?: bigint;
+  stethReceived: bigint;
+  sharesReceived: bigint;
 };
 
 export type StakeEncodeDataProps = {

--- a/packages/sdk/src/stake/types.ts
+++ b/packages/sdk/src/stake/types.ts
@@ -1,4 +1,4 @@
-import type { Account, Address } from 'viem';
+import type { Address, JsonRpcAccount } from 'viem';
 import { CommonTransactionProps } from '../core/types.js';
 import { EtherValue } from '../core/types.js';
 
@@ -10,7 +10,7 @@ export type StakeProps = CommonTransactionProps & {
 export type StakeInnerProps = CommonTransactionProps & {
   value: bigint;
   referralAddress: Address;
-  account: Account;
+  account: JsonRpcAccount;
 };
 
 export type StakeResult = {

--- a/packages/sdk/src/unsteth/types.ts
+++ b/packages/sdk/src/unsteth/types.ts
@@ -1,4 +1,9 @@
-import type { Hash, Address, ContractFunctionResult, Account } from 'viem';
+import type {
+  Hash,
+  Address,
+  ContractFunctionReturnType,
+  JsonRpcAccount,
+} from 'viem';
 import type {
   TransactionCallback,
   CommonTransactionProps,
@@ -6,8 +11,9 @@ import type {
 } from '../core/types.js';
 import type { unstethAbi } from './abi/unsteth-abi.js';
 
-export type UnstethNFTstatus = ContractFunctionResult<
+export type UnstethNFTstatus = ContractFunctionReturnType<
   typeof unstethAbi,
+  'view',
   'getWithdrawalStatus'
 >[number];
 
@@ -16,7 +22,7 @@ export type UnstethNFT = { id: bigint } & UnstethNFTstatus;
 export type ParsedProps<TProps extends CommonTransactionProps> = Omit<
   TProps,
   'callback' | 'account'
-> & { callback: TransactionCallback; account: Account };
+> & { callback: TransactionCallback; account: JsonRpcAccount };
 
 export type UnstethTransferProps = {
   to: Address;

--- a/packages/sdk/src/unsteth/unsteth.ts
+++ b/packages/sdk/src/unsteth/unsteth.ts
@@ -19,7 +19,6 @@ import type {
 import {
   type Address,
   type GetContractReturnType,
-  type PublicClient,
   type WalletClient,
   getContract,
   zeroAddress,
@@ -41,14 +40,16 @@ export class LidoSDKUnstETH extends LidoSDKModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['core.chain.id', 'contractAddressWstETH'])
   public async getContract(): Promise<
-    GetContractReturnType<typeof unstethAbi, PublicClient, WalletClient>
+    GetContractReturnType<typeof unstethAbi, WalletClient>
   > {
     const address = await this.contractAddress();
     return getContract({
       address,
       abi: unstethAbi,
-      publicClient: this.core.rpcProvider,
-      walletClient: this.core.web3Provider,
+      client: {
+        public: this.core.rpcProvider,
+        wallet: this.core.web3Provider as WalletClient,
+      },
     });
   }
 

--- a/packages/sdk/src/withdraw/__test__/withdraw-claim.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-claim.test.ts
@@ -78,5 +78,15 @@ describe('withdraw request claim', () => {
     const balanceAfter = await core.balanceETH(address);
     expect(balanceAfter - balanceBefore).toEqual(claimableETH - ethForGas);
     await expect(unsteth.getAccountByNFT(request.id)).rejects.toBeDefined();
+
+    expect(tx.result).toBeDefined();
+    expect(tx.result?.requests).toHaveLength(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const claimedRequest = tx.result!.requests[0]!;
+
+    expectAddress(claimedRequest.owner, address);
+    expectAddress(claimedRequest.receiver, address);
+    expect(claimedRequest.requestId).toEqual(request.id);
+    expect(claimedRequest.amountOfETH).toEqual(claimableETH);
   });
 });

--- a/packages/sdk/src/withdraw/__test__/withdraw-request.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-request.test.ts
@@ -1,6 +1,9 @@
 import { expect, describe, jest, beforeAll, test } from '@jest/globals';
 import { useWithdraw } from '../../../tests/utils/fixtures/use-withdraw.js';
-import { expectAlmostEqualBn } from '../../../tests/utils/expect/expect-bn.js';
+import {
+  expectAlmostEqualBn,
+  expectPositiveBn,
+} from '../../../tests/utils/expect/expect-bn.js';
 import { Address } from 'viem';
 import { useWrap } from '../../../tests/utils/fixtures/use-wrap.js';
 import { useAccount } from '../../../tests/utils/fixtures/use-wallet-client.js';
@@ -277,6 +280,17 @@ const testWithdrawals = (token: WithdrawableTokens, ethAmount: bigint) => {
 
     const nftsAfter = await unsteth.getNFTsByAccount(address);
     expect(nftsAfter.length - nftsBefore.length).toBe(requestsAmounts.length);
+
+    expect(tx.result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const result = tx.result!;
+    expect(result.requests).toHaveLength(nftsAfter.length - nftsBefore.length);
+    for (const request of result.requests) {
+      expectAddress(request.owner, address);
+      expectAddress(request.requestor, address);
+      expectPositiveBn(request.amountOfStETH);
+      expectPositiveBn(request.amountOfShares);
+    }
   });
 };
 

--- a/packages/sdk/src/withdraw/abi/withdrawalQueue.ts
+++ b/packages/sdk/src/withdraw/abi/withdrawalQueue.ts
@@ -146,7 +146,7 @@ export const WithdrawalQueueAbi = [
         type: 'address',
       },
       {
-        indexed: true,
+        indexed: false,
         internalType: 'uint256',
         name: 'tokenId',
         type: 'uint256',
@@ -353,7 +353,7 @@ export const WithdrawalQueueAbi = [
       { indexed: true, internalType: 'address', name: 'from', type: 'address' },
       { indexed: true, internalType: 'address', name: 'to', type: 'address' },
       {
-        indexed: true,
+        indexed: false,
         internalType: 'uint256',
         name: 'tokenId',
         type: 'uint256',
@@ -1118,5 +1118,76 @@ export const WithdrawalQueueAbi = [
     outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
     stateMutability: 'view',
     type: 'function',
+  },
+] as const;
+
+export const PartialWithdrawalQueueEventsAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'requestId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'requestor',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amountOfStETH',
+        type: 'uint256',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amountOfShares',
+        type: 'uint256',
+      },
+    ],
+    name: 'WithdrawalRequested',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: 'uint256',
+        name: 'requestId',
+        type: 'uint256',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'owner',
+        type: 'address',
+      },
+      {
+        indexed: true,
+        internalType: 'address',
+        name: 'receiver',
+        type: 'address',
+      },
+      {
+        indexed: false,
+        internalType: 'uint256',
+        name: 'amountOfETH',
+        type: 'uint256',
+      },
+    ],
+    name: 'WithdrawalClaimed',
+    type: 'event',
   },
 ] as const;

--- a/packages/sdk/src/withdraw/claim/types.ts
+++ b/packages/sdk/src/withdraw/claim/types.ts
@@ -1,6 +1,18 @@
+import type { Address } from 'viem';
 import type { CommonTransactionProps } from '../../core/index.js';
 
 export type ClaimRequestsProps = CommonTransactionProps & {
   requestsIds: readonly bigint[];
   hints?: readonly bigint[];
+};
+
+export type ClaimResultEvent = {
+  requestId: bigint;
+  owner: Address;
+  receiver: Address;
+  amountOfETH: bigint;
+};
+
+export type ClaimResult = {
+  requests: ClaimResultEvent[];
 };

--- a/packages/sdk/src/withdraw/index.ts
+++ b/packages/sdk/src/withdraw/index.ts
@@ -1,5 +1,9 @@
 export { LidoSDKWithdraw } from './withdraw.js';
-export type { ClaimRequestsProps } from './claim/types.js';
+export type {
+  ClaimRequestsProps,
+  ClaimResult,
+  ClaimResultEvent,
+} from './claim/types.js';
 export type {
   RequestProps,
   RequestWithPermitProps,
@@ -9,6 +13,8 @@ export type {
   GetAllowanceProps,
   SplitAmountToRequestsProps,
   PermitWstETHStETHProps,
+  WithdrawalResult,
+  WithdrawalEventRequest,
 } from './request/types.js';
 export type {
   RequestStatusWithId,

--- a/packages/sdk/src/withdraw/request/approve.ts
+++ b/packages/sdk/src/withdraw/request/approve.ts
@@ -1,4 +1,4 @@
-import { type SimulateContractReturnType, encodeFunctionData } from 'viem';
+import { encodeFunctionData } from 'viem';
 
 import type {
   NoCallback,
@@ -54,9 +54,7 @@ export class LidoSDKWithdrawApprove extends BusModule {
 
   @Logger('Views:')
   @ErrorHandler()
-  public async approveSimulateTx(
-    props: NoCallback<WithdrawApproveProps>,
-  ): Promise<SimulateContractReturnType> {
+  public async approveSimulateTx(props: NoCallback<WithdrawApproveProps>) {
     const account = await this.bus.core.useAccount(props.account);
     const { token, amount: _amount } = props;
     const amount = parseValue(_amount);

--- a/packages/sdk/src/withdraw/request/types.ts
+++ b/packages/sdk/src/withdraw/request/types.ts
@@ -75,3 +75,15 @@ export type CheckAllowanceResult = {
   allowance: bigint;
   needsApprove: boolean;
 };
+
+export type WithdrawalEventRequest = {
+  requestId: bigint;
+  requestor: Address;
+  owner: Address;
+  amountOfStETH: bigint;
+  amountOfShares: bigint;
+};
+
+export type WithdrawalResult = {
+  requests: WithdrawalEventRequest[];
+};

--- a/packages/sdk/src/withdraw/withdraw-contract.ts
+++ b/packages/sdk/src/withdraw/withdraw-contract.ts
@@ -1,10 +1,5 @@
 import { getContract } from 'viem';
-import type {
-  Address,
-  GetContractReturnType,
-  PublicClient,
-  WalletClient,
-} from 'viem';
+import type { Address, GetContractReturnType, WalletClient } from 'viem';
 import { Logger, Cache } from '../common/decorators/index.js';
 import { LIDO_CONTRACT_NAMES } from '../common/constants.js';
 
@@ -30,15 +25,17 @@ export class LidoSDKWithdrawContract extends BusModule {
     'contractAddressWithdrawalQueue',
   ])
   public async getContractWithdrawalQueue(): Promise<
-    GetContractReturnType<typeof WithdrawalQueueAbi, PublicClient, WalletClient>
+    GetContractReturnType<typeof WithdrawalQueueAbi, WalletClient>
   > {
     const address = await this.contractAddressWithdrawalQueue();
 
     return getContract({
       address,
       abi: WithdrawalQueueAbi,
-      publicClient: this.bus.core.rpcProvider,
-      walletClient: this.bus.core.web3Provider,
+      client: {
+        public: this.bus.core.rpcProvider,
+        wallet: this.bus.core.web3Provider as WalletClient,
+      },
     });
   }
 
@@ -51,15 +48,17 @@ export class LidoSDKWithdrawContract extends BusModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['bus.core.chain.id', 'contractAddressStETH'])
   public async getContractStETH(): Promise<
-    GetContractReturnType<typeof PartStethAbi, PublicClient, WalletClient>
+    GetContractReturnType<typeof PartStethAbi, WalletClient>
   > {
     const address = await this.contractAddressStETH();
 
     return getContract({
       address,
       abi: PartStethAbi,
-      publicClient: this.bus.core.rpcProvider,
-      walletClient: this.bus.core.web3Provider,
+      client: {
+        public: this.bus.core.rpcProvider,
+        wallet: this.bus.core.web3Provider as WalletClient,
+      },
     });
   }
 
@@ -72,15 +71,17 @@ export class LidoSDKWithdrawContract extends BusModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['bus.core.chain.id', 'contractAddressWstETH'])
   public async getContractWstETH(): Promise<
-    GetContractReturnType<typeof PartWstethAbi, PublicClient, WalletClient>
+    GetContractReturnType<typeof PartWstethAbi, WalletClient>
   > {
     const address = await this.contractAddressWstETH();
 
     return getContract({
       address,
       abi: PartWstethAbi,
-      publicClient: this.bus.core.rpcProvider,
-      walletClient: this.bus.core.web3Provider,
+      client: {
+        public: this.bus.core.rpcProvider,
+        wallet: this.bus.core.web3Provider as WalletClient,
+      },
     });
   }
 }

--- a/packages/sdk/src/wrap/__test__/wrap-wallet.test.ts
+++ b/packages/sdk/src/wrap/__test__/wrap-wallet.test.ts
@@ -84,8 +84,17 @@ describe('LidoSDKWrap wallet methods', () => {
     const stethBalanceAfter = await steth.balance(address);
     const wstethBalanceAfter = await wsteth.balance(address);
 
-    expectAlmostEqualBn(stethBalanceAfter - stethBalanceBefore, -value);
-    expectAlmostEqualBn(wstethBalanceAfter - wstethBalanceBefore, wstethValue);
+    const stethDiff = stethBalanceAfter - stethBalanceBefore;
+    const wstethDiff = wstethBalanceAfter - wstethBalanceBefore;
+
+    expectAlmostEqualBn(stethDiff, -value);
+    expectAlmostEqualBn(wstethDiff, wstethValue);
+
+    expect(tx.result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const result = tx.result!;
+    expectAlmostEqualBn(result.stethWrapped, -stethDiff);
+    expect(result.wstethReceived).toEqual(wstethDiff);
 
     await expect(wrap.getStethForWrapAllowance(address)).resolves.toEqual(0n);
   });
@@ -118,7 +127,16 @@ describe('LidoSDKWrap wallet methods', () => {
     const stethBalanceAfter = await steth.balance(address);
     const wstethBalanceAfter = await wsteth.balance(address);
 
-    expectAlmostEqualBn(stethBalanceAfter - stethBalanceBefore, value);
-    expectAlmostEqualBn(wstethBalanceAfter - wstethBalanceBefore, -wstethValue);
+    const stethDiff = stethBalanceAfter - stethBalanceBefore;
+    const wstethDiff = wstethBalanceAfter - wstethBalanceBefore;
+
+    expectAlmostEqualBn(stethDiff, value);
+    expectAlmostEqualBn(wstethDiff, -wstethValue);
+
+    expect(tx.result).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const result = tx.result!;
+    expectAlmostEqualBn(result.stethReceived, stethDiff);
+    expect(result.wstethUnwrapped).toEqual(-wstethDiff);
   });
 });

--- a/packages/sdk/src/wrap/abi/steth-partial.ts
+++ b/packages/sdk/src/wrap/abi/steth-partial.ts
@@ -70,4 +70,27 @@ export const stethPartialAbi = [
     name: 'TransferShares',
     type: 'event',
   },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'sender', type: 'address' },
+      { indexed: false, name: 'amount', type: 'uint256' },
+      { indexed: false, name: 'referral', type: 'address' },
+    ],
+    name: 'Submitted',
+    type: 'event',
+  },
+] as const;
+
+export const PartialTransferEventAbi = [
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'value', type: 'uint256' },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
 ] as const;

--- a/packages/sdk/src/wrap/abi/steth-partial.ts
+++ b/packages/sdk/src/wrap/abi/steth-partial.ts
@@ -40,4 +40,34 @@ export const stethPartialAbi = [
     stateMutability: 'view',
     type: 'function',
   },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'value', type: 'uint256' },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'owner', type: 'address' },
+      { indexed: true, name: 'spender', type: 'address' },
+      { indexed: false, name: 'value', type: 'uint256' },
+    ],
+    name: 'Approval',
+    type: 'event',
+  },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'sharesValue', type: 'uint256' },
+    ],
+    name: 'TransferShares',
+    type: 'event',
+  },
 ] as const;

--- a/packages/sdk/src/wrap/abi/wsteth.ts
+++ b/packages/sdk/src/wrap/abi/wsteth.ts
@@ -57,14 +57,4 @@ export const abi = [
     type: 'function',
   },
   { stateMutability: 'payable', type: 'receive' },
-  {
-    anonymous: false,
-    inputs: [
-      { indexed: true, name: 'from', type: 'address' },
-      { indexed: true, name: 'to', type: 'address' },
-      { indexed: false, name: 'value', type: 'uint256' },
-    ],
-    name: 'Transfer',
-    type: 'event',
-  },
 ] as const;

--- a/packages/sdk/src/wrap/abi/wsteth.ts
+++ b/packages/sdk/src/wrap/abi/wsteth.ts
@@ -57,4 +57,14 @@ export const abi = [
     type: 'function',
   },
   { stateMutability: 'payable', type: 'receive' },
+  {
+    anonymous: false,
+    inputs: [
+      { indexed: true, name: 'from', type: 'address' },
+      { indexed: true, name: 'to', type: 'address' },
+      { indexed: false, name: 'value', type: 'uint256' },
+    ],
+    name: 'Transfer',
+    type: 'event',
+  },
 ] as const;

--- a/packages/sdk/src/wrap/types.ts
+++ b/packages/sdk/src/wrap/types.ts
@@ -1,4 +1,4 @@
-import type { Account, FormattedTransactionRequest } from 'viem';
+import type { FormattedTransactionRequest, JsonRpcAccount } from 'viem';
 import type { EtherValue, CommonTransactionProps } from '../core/types.js';
 
 export type WrapProps = CommonTransactionProps & {
@@ -19,7 +19,7 @@ export type WrapPropsWithoutCallback = Omit<WrapProps, 'callback'>;
 
 export type WrapInnerProps = Omit<CommonTransactionProps, 'account'> & {
   value: bigint;
-  account: Account;
+  account: JsonRpcAccount;
 };
 
 export type PopulatedTx = Omit<FormattedTransactionRequest, 'type'>;

--- a/packages/sdk/src/wrap/types.ts
+++ b/packages/sdk/src/wrap/types.ts
@@ -10,6 +10,11 @@ export type WrapResults = {
   wstethReceived: bigint;
 };
 
+export type UnwrapResults = {
+  wstethUnwrapped: bigint;
+  stethReceived: bigint;
+};
+
 export type WrapPropsWithoutCallback = Omit<WrapProps, 'callback'>;
 
 export type WrapInnerProps = Omit<CommonTransactionProps, 'account'> & {

--- a/packages/sdk/src/wrap/types.ts
+++ b/packages/sdk/src/wrap/types.ts
@@ -5,6 +5,11 @@ export type WrapProps = CommonTransactionProps & {
   value: EtherValue;
 };
 
+export type WrapResults = {
+  stethWrapped: bigint;
+  wstethReceived: bigint;
+};
+
 export type WrapPropsWithoutCallback = Omit<WrapProps, 'callback'>;
 
 export type WrapInnerProps = Omit<CommonTransactionProps, 'account'> & {

--- a/packages/sdk/src/wrap/wrap.ts
+++ b/packages/sdk/src/wrap/wrap.ts
@@ -83,9 +83,9 @@ export class LidoSDKWrap extends LidoSDKModule {
       abi: stethPartialAbi,
       client: {
         public: this.core.rpcProvider,
-        wallet: this.core.web3Provider,
+        wallet: this.core.web3Provider as WalletClient,
       },
-    }) as GetContractReturnType<typeof stethPartialAbi, WalletClient>;
+    });
   }
 
   // Calls

--- a/packages/sdk/tests/global-setup.cjs
+++ b/packages/sdk/tests/global-setup.cjs
@@ -25,7 +25,7 @@ module.exports = async function () {
     chain: { chainId, asyncRequestProcessing: false },
   });
 
-  console.debug('Initializing ganache provider...');
+  console.debug('\nInitializing ganache provider...');
   await ganacheProvider.initialize();
   console.debug('Initialized ganache provider');
 

--- a/packages/sdk/tests/global-teardown.cjs
+++ b/packages/sdk/tests/global-teardown.cjs
@@ -1,0 +1,7 @@
+module.exports = async function () {
+  if (globalThis.__ganache_provider__) {
+    console.debug('Disconnecting ganache provider...');
+    await globalThis.__ganache_provider__.disconnect();
+    console.debug('Disconnected ganache provider');
+  }
+};

--- a/packages/sdk/tests/utils/expect/expect-erc20-wallet.ts
+++ b/packages/sdk/tests/utils/expect/expect-erc20-wallet.ts
@@ -72,8 +72,10 @@ export const expectERC20Wallet = <I extends AbstractLidoSDKErc20>({
     return getContract({
       address,
       abi: erc20abi,
-      publicClient: rpcCore.rpcProvider,
-      walletClient: web3Core.web3Provider,
+      client: {
+        public: rpcCore.rpcProvider,
+        wallet: web3Core.web3Provider,
+      },
     });
   };
 

--- a/packages/sdk/tests/utils/expect/expect-erc20.ts
+++ b/packages/sdk/tests/utils/expect/expect-erc20.ts
@@ -37,12 +37,14 @@ export const expectERC20 = <I extends AbstractLidoSDKErc20>({
     return getContract({
       address,
       abi: erc20abi,
-      publicClient: rpcCore.rpcProvider,
-      walletClient: web3Core.web3Provider,
+      client: {
+        public: rpcCore.rpcProvider,
+        wallet: web3Core.web3Provider,
+      },
     });
   };
 
-  describe('construModulePrototype', () => {
+  describe('constructModulePrototype', () => {
     test('is correct module', () => {
       expectSDKModule(ModulePrototype);
     });

--- a/playground/package.json
+++ b/playground/package.json
@@ -43,7 +43,7 @@
     "styled-components": "^5.3.5",
     "swr": "^1.3.0",
     "tiny-invariant": "^1.3.1",
-    "viem": "^1.10.3",
+    "viem": "^2.0.6",
     "wagmi": "^0.12.19"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,10 +12,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@adraffy/ens-normalize@npm:1.9.4":
-  version: 1.9.4
-  resolution: "@adraffy/ens-normalize@npm:1.9.4"
-  checksum: 7d7fff58ebe2c4961f7e5e61dad123aa6a63fec0df5c84af1fa41079dc05d398599690be4427b3a94d2baa94084544bcfdf2d51cbed7504b9b0583b0960ad550
+"@adraffy/ens-normalize@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@adraffy/ens-normalize@npm:1.10.0"
+  checksum: af0540f963a2632da2bbc37e36ea6593dcfc607b937857133791781e246d47f870d5e3d21fa70d5cfe94e772c284588c81ea3f5b7f4ea8fbb824369444e4dbcb
   languageName: node
   linkType: hard
 
@@ -3093,11 +3093,12 @@ __metadata:
     graphql: ^16.8.1
     graphql-request: ^6.1.0
     jest: ^29.7.0
+    leaked-handles: ^5.2.0
     node-fetch: ^2.6.7
     rimraf: ^5.0.1
     ts-jest: ^29.1.1
     typescript: 5.1.6
-    viem: ^1.18.8
+    viem: ^2.0.6
   languageName: unknown
   linkType: soft
 
@@ -5211,15 +5212,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/ws@npm:^8.5.5":
-  version: 8.5.5
-  resolution: "@types/ws@npm:8.5.5"
-  dependencies:
-    "@types/node": "*"
-  checksum: d00bf8070e6938e3ccf933010921c6ce78ac3606696ce37a393b27a9a603f7bd93ea64f3c5fa295a2f743575ba9c9a9fdb904af0f5fe2229bf2adf0630386e4a
-  languageName: node
-  linkType: hard
-
 "@types/yargs-parser@npm:*":
   version: 21.0.2
   resolution: "@types/yargs-parser@npm:21.0.2"
@@ -5916,18 +5908,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abitype@npm:0.9.8":
-  version: 0.9.8
-  resolution: "abitype@npm:0.9.8"
+"abitype@npm:0.10.0":
+  version: 0.10.0
+  resolution: "abitype@npm:0.10.0"
   peerDependencies:
     typescript: ">=5.0.4"
-    zod: ^3 >=3.19.1
+    zod: ^3 >=3.22.0
   peerDependenciesMeta:
     typescript:
       optional: true
     zod:
       optional: true
-  checksum: d7d887f29d6821e3f7a400de9620511b80ead3f85c5c87308aaec97965d3493e6687ed816e88722b4f512249bd66dee9e69231b49af0e1db8f69400a62c87cf6
+  checksum: 01a75393740036121414024aa7ed61e6a2104bfd90c91b6aa1a7778cf1edfa15b828779acbbb13ac641939d1ba9c836d143d9f7310699cd7496273bb24c599b3
   languageName: node
   linkType: hard
 
@@ -10304,15 +10296,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isomorphic-ws@npm:5.0.0":
-  version: 5.0.0
-  resolution: "isomorphic-ws@npm:5.0.0"
-  peerDependencies:
-    ws: "*"
-  checksum: e20eb2aee09ba96247465fda40c6d22c1153394c0144fa34fe6609f341af4c8c564f60ea3ba762335a7a9c306809349f9b863c8beedf2beea09b299834ad5398
-  languageName: node
-  linkType: hard
-
 "isomorphic-ws@npm:^4.0.1":
   version: 4.0.1
   resolution: "isomorphic-ws@npm:4.0.1"
@@ -11160,6 +11143,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"leaked-handles@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "leaked-handles@npm:5.2.0"
+  dependencies:
+    process: ^0.10.0
+    weakmap-shim: ^1.1.0
+    xtend: ^4.0.0
+  checksum: 4d4d950a01a42ff9084a8ed9f70df47e94ebbf9553846ad7fe269821382c97f4ac97034a023c4dad6457514877e0ae427443c326e7723ad87e73b73e5045cb8f
+  languageName: node
+  linkType: hard
+
 "legacy-swc-helpers@npm:@swc/helpers@=0.4.14":
   version: 0.4.14
   resolution: "@swc/helpers@npm:0.4.14"
@@ -11439,7 +11433,7 @@ __metadata:
     tiny-invariant: ^1.3.1
     typescript: 5.1.6
     url-loader: ^4.1.1
-    viem: ^1.10.3
+    viem: ^2.0.6
     wagmi: ^0.12.19
   languageName: unknown
   linkType: soft
@@ -13371,6 +13365,13 @@ __metadata:
   version: 2.2.0
   resolution: "process-warning@npm:2.2.0"
   checksum: 394ae451c2622ee7d014a7196d36658fc1a5d5cc9f3bfeb54aadd5b77fcfecc89a30a25db259ae76ff49fde3f3f3dd7031dcdfb4da2e5445dac795549352e5d0
+  languageName: node
+  linkType: hard
+
+"process@npm:^0.10.0":
+  version: 0.10.1
+  resolution: "process@npm:0.10.1"
+  checksum: bdaaa28a8edf96d5daa0f5c1faf4adfedce512ebca829a82e846d991492780c34eb934decf4fa5b311c698881d07a8d4592b4d7ea53ec03d51580a2f364d3e30
   languageName: node
   linkType: hard
 
@@ -16032,38 +16033,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:^1.10.3":
-  version: 1.10.9
-  resolution: "viem@npm:1.10.9"
+"viem@npm:^2.0.6":
+  version: 2.0.6
+  resolution: "viem@npm:2.0.6"
   dependencies:
-    "@adraffy/ens-normalize": 1.9.4
+    "@adraffy/ens-normalize": 1.10.0
     "@noble/curves": 1.2.0
     "@noble/hashes": 1.3.2
     "@scure/bip32": 1.3.2
     "@scure/bip39": 1.2.1
-    "@types/ws": ^8.5.5
-    abitype: 0.9.8
-    isomorphic-ws: 5.0.0
-    ws: 8.13.0
-  peerDependencies:
-    typescript: ">=5.0.4"
-  peerDependenciesMeta:
-    typescript:
-      optional: true
-  checksum: 7bf53044abff4ff703d518227921d9a56907be744a30750873231a442dcfdee485d9928f337e22ad698a4d0cf25a57194aee9e636a09233169721bf2a6f2eea0
-  languageName: node
-  linkType: hard
-
-"viem@npm:^1.18.8":
-  version: 1.18.8
-  resolution: "viem@npm:1.18.8"
-  dependencies:
-    "@adraffy/ens-normalize": 1.9.4
-    "@noble/curves": 1.2.0
-    "@noble/hashes": 1.3.2
-    "@scure/bip32": 1.3.2
-    "@scure/bip39": 1.2.1
-    abitype: 0.9.8
+    abitype: 0.10.0
     isows: 1.0.3
     ws: 8.13.0
   peerDependencies:
@@ -16071,7 +16050,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 735e7debb20592b8c629f54a909c1c4b2f6d5d83ecb85eae15f066df55c9938153be87f7e635d925562ef7c8c600f9778e6f4dc83a76953d2ea1e118914d83db
+  checksum: eb6d17922c9eba640f4dc41e2f263c38033191da0328d0ff6ce710111368b65326fd7e680600dce1d87e4604c7b1898702bb1cdb333625d9c3cfb552f2739f08
   languageName: node
   linkType: hard
 
@@ -16128,6 +16107,13 @@ __metadata:
   dependencies:
     defaults: ^1.0.3
   checksum: 814e9d1ddcc9798f7377ffa448a5a3892232b9275ebb30a41b529607691c0491de47cba426e917a4d08ded3ee7e9ba2f3fe32e62ee3cd9c7d3bafb7754bd553c
+  languageName: node
+  linkType: hard
+
+"weakmap-shim@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "weakmap-shim@npm:1.1.1"
+  checksum: 27669feb2a05d881211a298fafb1e771fd960a5e308b89a66db2902328f0afdb9c91524bd401d45700918baa84f082017c70cbd56a89ae37c18584c0f00ee0e6
   languageName: node
   linkType: hard
 
@@ -16354,7 +16340,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.1, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a

--- a/yarn.lock
+++ b/yarn.lock
@@ -3093,7 +3093,6 @@ __metadata:
     graphql: ^16.8.1
     graphql-request: ^6.1.0
     jest: ^29.7.0
-    leaked-handles: ^5.2.0
     node-fetch: ^2.6.7
     rimraf: ^5.0.1
     ts-jest: ^29.1.1
@@ -11143,17 +11142,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"leaked-handles@npm:^5.2.0":
-  version: 5.2.0
-  resolution: "leaked-handles@npm:5.2.0"
-  dependencies:
-    process: ^0.10.0
-    weakmap-shim: ^1.1.0
-    xtend: ^4.0.0
-  checksum: 4d4d950a01a42ff9084a8ed9f70df47e94ebbf9553846ad7fe269821382c97f4ac97034a023c4dad6457514877e0ae427443c326e7723ad87e73b73e5045cb8f
-  languageName: node
-  linkType: hard
-
 "legacy-swc-helpers@npm:@swc/helpers@=0.4.14":
   version: 0.4.14
   resolution: "@swc/helpers@npm:0.4.14"
@@ -13365,13 +13353,6 @@ __metadata:
   version: 2.2.0
   resolution: "process-warning@npm:2.2.0"
   checksum: 394ae451c2622ee7d014a7196d36658fc1a5d5cc9f3bfeb54aadd5b77fcfecc89a30a25db259ae76ff49fde3f3f3dd7031dcdfb4da2e5445dac795549352e5d0
-  languageName: node
-  linkType: hard
-
-"process@npm:^0.10.0":
-  version: 0.10.1
-  resolution: "process@npm:0.10.1"
-  checksum: bdaaa28a8edf96d5daa0f5c1faf4adfedce512ebca829a82e846d991492780c34eb934decf4fa5b311c698881d07a8d4592b4d7ea53ec03d51580a2f364d3e30
   languageName: node
   linkType: hard
 
@@ -16110,13 +16091,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"weakmap-shim@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "weakmap-shim@npm:1.1.1"
-  checksum: 27669feb2a05d881211a298fafb1e771fd960a5e308b89a66db2902328f0afdb9c91524bd401d45700918baa84f082017c70cbd56a89ae37c18584c0f00ee0e6
-  languageName: node
-  linkType: hard
-
 "webidl-conversions@npm:^3.0.0":
   version: 3.0.1
   resolution: "webidl-conversions@npm:3.0.1"
@@ -16340,7 +16314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"xtend@npm:^4.0.0, xtend@npm:^4.0.1, xtend@npm:~4.0.1":
+"xtend@npm:^4.0.1, xtend@npm:~4.0.1":
   version: 4.0.2
   resolution: "xtend@npm:4.0.2"
   checksum: ac5dfa738b21f6e7f0dd6e65e1b3155036d68104e67e5d5d1bde74892e327d7e5636a076f625599dc394330a731861e87343ff184b0047fef1360a7ec0a5a36a


### PR DESCRIPTION
### Description
For every tx parse logs to return results alongside confirmations, like:
- [x] stake
- [x] wrapEth
- [x] wrapSteth
- [x] unwrap
- [x] withdraw
- [x] claim

Also:

- [x] upgrade viem to 2.x
- [x] tests
- [x] update docs

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

- after upgrading viem, had to remove return types for `simulate` methods because viem types are better and more accurate but too complex to repeat in method signature
also had to hack types for `useAccount` and `getContract`
- Viem wants to know in advance if we have walletClient and this would complex sdk types, so we cast contract to have write methods(even if there is no walletClient)
-  Also contract methods now don't allow `LocalAccount` to be passed, so I had to type `useAccount` to return `jsonRpcAccount`, (tests work though)

### Testing notes

Updated are covered by tests, but needs minor recheck with real wallets 

### Checklist:

- [x]  Checked the changes locally.
- [x]  Created/updated unit tests.
- [x]  Created/updated README.md.

