### PR TITLE
[Fix] stake populate tx

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - better multisig behavior for transactions
 - Simulate methods now have correct return types
+- `stakeEthPopulateTx` not does not calculate `gasLimit` which prevented usage when stake limit is reached
 
 ## Playground
 

--- a/packages/sdk/src/stake/stake.ts
+++ b/packages/sdk/src/stake/stake.ts
@@ -240,15 +240,10 @@ export class LidoSDKStake extends LidoSDKModule {
     const { referralAddress, value, account } = await this.parseProps(props);
     const data = this.stakeEthEncodeData({ referralAddress });
     const address = await this.contractAddressStETH();
-    const gas = await this.submitGasLimit(value, referralAddress, {
-      account,
-      chain: this.core.chain,
-    });
     return {
       to: address,
       from: account.address,
       value,
-      gas,
       data,
     };
   }


### PR DESCRIPTION
### Description
`stakeEthPopulateTx` not does not calculate `gasLimit` which prevented usage when stake limit is reached

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [x]  Created/updated README.md.

