### PR TITLE
[fix] use correct address comparison in reward history

### DIFF
--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.2.1
+
+## SDK
+
+### Fixed
+
+- fixed edge-cases in `getRewardsFromChain` and `getRewardsFromSubgraph` sometimes causing transfer events to be wronged and leading to negative balance
+
 # 3.2.0
 
 ## SDK

--- a/packages/sdk/src/common/utils/address-equal.ts
+++ b/packages/sdk/src/common/utils/address-equal.ts
@@ -1,4 +1,7 @@
 import { Address } from 'viem';
 
+/**
+ * @deprecated use native viem isAddressEqual
+ */
 export const addressEqual = (a: Address | string, b: Address | string) =>
   a.toLowerCase() === b.toLowerCase();

--- a/packages/sdk/src/rewards/rewards.ts
+++ b/packages/sdk/src/rewards/rewards.ts
@@ -4,6 +4,7 @@ import {
   type PublicClient,
   getContract,
   zeroAddress,
+  isAddressEqual,
 } from 'viem';
 import { Logger, ErrorHandler, Cache } from '../common/decorators/index.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
@@ -31,7 +32,6 @@ import {
   getTotalRewards,
   getTransfers,
 } from './subgraph/index.js';
-import { addressEqual } from '../common/utils/address-equal.js';
 import { getInitialData } from './subgraph/index.js';
 import { calcShareRate, requestWithBlockStep, sharesToSteth } from './utils.js';
 import {
@@ -193,12 +193,14 @@ export class LidoSDKRewards extends LidoSDKModule {
           changeShares: Reward<RewardsChainEvents>['changeShares'],
           balanceShares: Reward<RewardsChainEvents>['balanceShares'];
 
-        if (to === address) {
-          type = from === zeroAddress ? 'submit' : 'transfer_in';
+        if (isAddressEqual(to, address)) {
+          type = isAddressEqual(from, zeroAddress) ? 'submit' : 'transfer_in';
           balanceShares = prevSharesBalance + sharesValue;
           changeShares = sharesValue;
         } else {
-          type = to === withdrawalQueueAddress ? 'withdrawal' : 'transfer_out';
+          type = isAddressEqual(to, withdrawalQueueAddress)
+            ? 'withdrawal'
+            : 'transfer_out';
           balanceShares = prevSharesBalance - sharesValue;
           changeShares = -sharesValue;
         }
@@ -338,10 +340,10 @@ export class LidoSDKRewards extends LidoSDKModule {
         sharesAfterDecrease,
         sharesAfterIncrease,
       } = initialTransfer;
-      if (addressEqual(to, address)) {
+      if (isAddressEqual(to as Address, address)) {
         prevBalanceShares = BigInt(sharesAfterIncrease);
         prevBalance = BigInt(balanceAfterIncrease);
-      } else if (addressEqual(from, address)) {
+      } else if (isAddressEqual(from as Address, address)) {
         prevBalanceShares = BigInt(sharesAfterDecrease);
         prevBalance = BigInt(balanceAfterDecrease);
       }
@@ -393,14 +395,16 @@ export class LidoSDKRewards extends LidoSDKModule {
           change: Reward<RewardsSubgraphEvents>['change'],
           balance: Reward<RewardsSubgraphEvents>['balance'];
 
-        if (addressEqual(to, address)) {
-          type = from === zeroAddress ? 'submit' : 'transfer_in';
+        if (isAddressEqual(to as Address, address)) {
+          type = isAddressEqual(from as Address, zeroAddress)
+            ? 'submit'
+            : 'transfer_in';
           changeShares = BigInt(shares);
           balanceShares = BigInt(sharesAfterIncrease);
           change = BigInt(value);
           balance = BigInt(balanceAfterIncrease);
         } else {
-          type = addressEqual(to, withdrawalQueueAddress)
+          type = isAddressEqual(to as Address, withdrawalQueueAddress)
             ? 'withdrawal'
             : 'transfer_out';
           balance = BigInt(balanceAfterDecrease);

--- a/packages/sdk/src/stake/stake.ts
+++ b/packages/sdk/src/stake/stake.ts
@@ -5,6 +5,7 @@ import {
   decodeEventLog,
   getAbiItem,
   getEventSelector,
+  isAddressEqual,
 } from 'viem';
 
 import type {
@@ -40,7 +41,6 @@ import type {
   StakeResult,
 } from './types.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
-import { addressEqual } from '../common/utils/address-equal.js';
 
 export class LidoSDKStake extends LidoSDKModule {
   // Precomputed event signatures
@@ -188,12 +188,12 @@ export class LidoSDKStake extends LidoSDKModule {
       });
       if (
         parsedLog.eventName === 'Transfer' &&
-        addressEqual(parsedLog.args.to, address)
+        isAddressEqual(parsedLog.args.to, address)
       ) {
         stethReceived = parsedLog.args.value;
       } else if (
         parsedLog.eventName === 'TransferShares' &&
-        addressEqual(parsedLog.args.to, address)
+        isAddressEqual(parsedLog.args.to, address)
       ) {
         sharesReceived = parsedLog.args.sharesValue;
       }

--- a/packages/sdk/src/wrap/wrap.ts
+++ b/packages/sdk/src/wrap/wrap.ts
@@ -10,6 +10,7 @@ import {
   decodeEventLog,
   getAbiItem,
   getEventSelector,
+  isAddressEqual,
 } from 'viem';
 
 import { LIDO_CONTRACT_NAMES, NOOP } from '../common/constants.js';
@@ -37,7 +38,6 @@ import {
 } from './abi/steth-partial.js';
 import { ERROR_CODE, invariant } from '../common/utils/sdk-error.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
-import { addressEqual } from '../common/utils/address-equal.js';
 
 export class LidoSDKWrap extends LidoSDKModule {
   private static TRANSFER_SIGNATURE = getEventSelector(
@@ -397,9 +397,9 @@ export class LidoSDKWrap extends LidoSDKModule {
         strict: true,
         ...log,
       });
-      if (addressEqual(parsedLog.args.to, address)) {
+      if (isAddressEqual(parsedLog.args.to, address)) {
         wstethReceived = parsedLog.args.value;
-      } else if (addressEqual(parsedLog.args.to, wstethAddress)) {
+      } else if (isAddressEqual(parsedLog.args.to, wstethAddress)) {
         stethWrapped = parsedLog.args.value;
       }
     }
@@ -434,9 +434,9 @@ export class LidoSDKWrap extends LidoSDKModule {
         strict: true,
         ...log,
       });
-      if (addressEqual(parsedLog.args.from, address)) {
+      if (isAddressEqual(parsedLog.args.from, address)) {
         wstethUnwrapped = parsedLog.args.value;
-      } else if (addressEqual(parsedLog.args.to, address)) {
+      } else if (isAddressEqual(parsedLog.args.to, address)) {
         stethReceived = parsedLog.args.value;
       }
     }


### PR DESCRIPTION
### Description

Fixed edge-cases in `getRewardsFromChain` and `getRewardsFromSubgraph` sometimes causing transfer events to be   parsed wrong and accumulating negative balance.   

### Checklist:

- [x]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

