### PR TITLE
[FIX] `Cannot find hints for unfinalized request` error

### DIFF
--- a/.eslintrc.base.json
+++ b/.eslintrc.base.json
@@ -9,8 +9,9 @@
   "parserOptions": {
     "sourceType": "module"
   },
-  "plugins": ["@typescript-eslint", "react"],
+  "plugins": ["@typescript-eslint", "react", "deprecation"],
   "rules": {
+    "deprecation/deprecation": "warn",
     "@typescript-eslint/require-await": "off",
     "react/display-name": "off",
     "@typescript-eslint/no-shadow": "off",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-config-prettier": "^8.5.0",
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^3",
+    "eslint-plugin-deprecation": "^2.0.0",
     "eslint-plugin-eslint-comments": "^3",
     "eslint-plugin-import": "^2",
     "eslint-plugin-jest": "^27",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 3.2.2
+
+## SDK
+
+### Fixed
+
+- fixed edge-case in `withdraw.views.findCheckpointHints` where last finalized request would fail assertion with `Cannot find hints for unfinalized request...`
+- subsequently fixed same error in `withdraw.request-info`, `withdraw.claim` modules
+
+# 3.2.0
+
 # 3.2.1
 
 ## SDK

--- a/packages/sdk/src/common/utils/index.ts
+++ b/packages/sdk/src/common/utils/index.ts
@@ -1,3 +1,4 @@
 export { SDKError, type SDKErrorProps, ERROR_CODE } from './sdk-error.js';
 export { isBigint } from './is-bigint.js';
+// eslint-disable-next-line deprecation/deprecation
 export { addressEqual } from './address-equal.js';

--- a/packages/sdk/src/stake/stake.ts
+++ b/packages/sdk/src/stake/stake.ts
@@ -4,7 +4,7 @@ import {
   encodeFunctionData,
   decodeEventLog,
   getAbiItem,
-  getEventSelector,
+  toEventSignature,
   isAddressEqual,
 } from 'viem';
 
@@ -44,10 +44,10 @@ import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 export class LidoSDKStake extends LidoSDKModule {
   // Precomputed event signatures
-  private static TRANSFER_SIGNATURE = getEventSelector(
+  private static TRANSFER_SIGNATURE = toEventSignature(
     getAbiItem({ abi: StethEventsPartialAbi, name: 'Transfer' }),
   );
-  private static TRANSFER_SHARES_SIGNATURE = getEventSelector(
+  private static TRANSFER_SHARES_SIGNATURE = toEventSignature(
     getAbiItem({ abi: StethEventsPartialAbi, name: 'TransferShares' }),
   );
   // Contracts

--- a/packages/sdk/src/stake/stake.ts
+++ b/packages/sdk/src/stake/stake.ts
@@ -4,7 +4,7 @@ import {
   encodeFunctionData,
   decodeEventLog,
   getAbiItem,
-  toEventSignature,
+  toEventHash,
   isAddressEqual,
 } from 'viem';
 
@@ -44,10 +44,10 @@ import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 export class LidoSDKStake extends LidoSDKModule {
   // Precomputed event signatures
-  private static TRANSFER_SIGNATURE = toEventSignature(
+  private static TRANSFER_SIGNATURE = toEventHash(
     getAbiItem({ abi: StethEventsPartialAbi, name: 'Transfer' }),
   );
-  private static TRANSFER_SHARES_SIGNATURE = toEventSignature(
+  private static TRANSFER_SHARES_SIGNATURE = toEventHash(
     getAbiItem({ abi: StethEventsPartialAbi, name: 'TransferShares' }),
   );
   // Contracts

--- a/packages/sdk/src/withdraw/__test__/withdraw-views.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-views.test.ts
@@ -109,7 +109,7 @@ describe('withdraw views', () => {
       await contract.getContractWithdrawalQueue()
     ).read.getLastFinalizedRequestId();
 
-    expectSDKError(async () => {
+    await expectSDKError(async () => {
       await views.findCheckpointHints({
         sortedIds: [lastFinalizedRequestId + 1n],
       });

--- a/packages/sdk/src/withdraw/__test__/withdraw-views.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-views.test.ts
@@ -9,11 +9,13 @@ import { parseEther } from 'viem';
 import { useWrap } from '../../../tests/utils/fixtures/use-wrap.js';
 import { useAccount } from '../../../tests/utils/fixtures/use-wallet-client.js';
 import { expectAddress } from '../../../tests/utils/expect/expect-address.js';
+import { expectSDKError } from '../../../tests/utils/expect/expect-sdk-error.js';
+import { ERROR_CODE } from '../../common/index.js';
 
 describe('withdraw views', () => {
   const withdraw = useWithdraw();
   const wrap = useWrap();
-  const { views } = withdraw;
+  const { views, contract } = withdraw;
   const { address } = useAccount();
 
   const requestCount = 10;
@@ -85,6 +87,33 @@ describe('withdraw views', () => {
     for (const ether of ethers) {
       expectPositiveBn(ether);
     }
+  });
+
+  test('can findCheckpointHints for border requests', async () => {
+    const lastFinalizedRequestId = await (
+      await contract.getContractWithdrawalQueue()
+    ).read.getLastFinalizedRequestId();
+
+    const lastCheckpointIndex = await views.getLastCheckpointIndex();
+
+    const [checkpointFirst, checkpointLast] = await views.findCheckpointHints({
+      sortedIds: [1n, lastFinalizedRequestId],
+    });
+
+    expect(checkpointFirst).toEqual(1n);
+    expect(checkpointLast).toEqual(lastCheckpointIndex);
+  });
+
+  test('findCheckpointHints errors for unfinalized requests', async () => {
+    const lastFinalizedRequestId = await (
+      await contract.getContractWithdrawalQueue()
+    ).read.getLastFinalizedRequestId();
+
+    expectSDKError(async () => {
+      await views.findCheckpointHints({
+        sortedIds: [lastFinalizedRequestId + 1n],
+      });
+    }, ERROR_CODE.INVALID_ARGUMENT);
   });
 
   test('can get withdrawal request ids and statues', async () => {

--- a/packages/sdk/src/withdraw/claim/claim.ts
+++ b/packages/sdk/src/withdraw/claim/claim.ts
@@ -3,7 +3,7 @@ import {
   TransactionReceipt,
   decodeEventLog,
   getAbiItem,
-  toEventSignature,
+  toEventHash,
 } from 'viem';
 
 import { Logger, ErrorHandler } from '../../common/decorators/index.js';
@@ -26,7 +26,7 @@ import { PartialWithdrawalQueueEventsAbi } from '../abi/withdrawalQueue.js';
 
 export class LidoSDKWithdrawClaim extends BusModule {
   // Precomputed event signatures
-  private static CLAIM_SIGNATURE = toEventSignature(
+  private static CLAIM_SIGNATURE = toEventHash(
     getAbiItem({
       abi: PartialWithdrawalQueueEventsAbi,
       name: 'WithdrawalClaimed',

--- a/packages/sdk/src/withdraw/claim/claim.ts
+++ b/packages/sdk/src/withdraw/claim/claim.ts
@@ -3,7 +3,7 @@ import {
   TransactionReceipt,
   decodeEventLog,
   getAbiItem,
-  getEventSelector,
+  toEventSignature,
 } from 'viem';
 
 import { Logger, ErrorHandler } from '../../common/decorators/index.js';
@@ -26,7 +26,7 @@ import { PartialWithdrawalQueueEventsAbi } from '../abi/withdrawalQueue.js';
 
 export class LidoSDKWithdrawClaim extends BusModule {
   // Precomputed event signatures
-  private static CLAIM_SIGNATURE = getEventSelector(
+  private static CLAIM_SIGNATURE = toEventSignature(
     getAbiItem({
       abi: PartialWithdrawalQueueEventsAbi,
       name: 'WithdrawalClaimed',

--- a/packages/sdk/src/withdraw/request/request.ts
+++ b/packages/sdk/src/withdraw/request/request.ts
@@ -31,14 +31,14 @@ import {
   encodeFunctionData,
   formatEther,
   getAbiItem,
-  getEventSelector,
+  toEventSignature,
 } from 'viem';
 import { parseValue } from '../../common/utils/parse-value.js';
 import { PartialWithdrawalQueueEventsAbi } from '../abi/withdrawalQueue.js';
 
 export class LidoSDKWithdrawRequest extends BusModule {
   // Precomputed event signatures
-  private static WITHDRAW_SIGNATURE = getEventSelector(
+  private static WITHDRAW_SIGNATURE = toEventSignature(
     getAbiItem({
       abi: PartialWithdrawalQueueEventsAbi,
       name: 'WithdrawalRequested',

--- a/packages/sdk/src/withdraw/request/request.ts
+++ b/packages/sdk/src/withdraw/request/request.ts
@@ -31,14 +31,14 @@ import {
   encodeFunctionData,
   formatEther,
   getAbiItem,
-  toEventSignature,
+  toEventHash,
 } from 'viem';
 import { parseValue } from '../../common/utils/parse-value.js';
 import { PartialWithdrawalQueueEventsAbi } from '../abi/withdrawalQueue.js';
 
 export class LidoSDKWithdrawRequest extends BusModule {
   // Precomputed event signatures
-  private static WITHDRAW_SIGNATURE = toEventSignature(
+  private static WITHDRAW_SIGNATURE = toEventHash(
     getAbiItem({
       abi: PartialWithdrawalQueueEventsAbi,
       name: 'WithdrawalRequested',

--- a/packages/sdk/src/withdraw/withdraw-views.ts
+++ b/packages/sdk/src/withdraw/withdraw-views.ts
@@ -58,7 +58,7 @@ export class LidoSDKWithdrawViews extends BusModule {
     for (let index = sortedIds.length - 1; index >= 0; index--) {
       const id = sortedIds[index];
       invariantArgument(
-        id && id < lastFinalizedRequestId,
+        id && id <= lastFinalizedRequestId,
         `Cannot find hints for unfinalized request ${id?.toString()}`,
       );
     }

--- a/packages/sdk/src/wrap/wrap.ts
+++ b/packages/sdk/src/wrap/wrap.ts
@@ -9,7 +9,7 @@ import {
   TransactionReceipt,
   decodeEventLog,
   getAbiItem,
-  toEventSignature,
+  toEventHash,
   isAddressEqual,
 } from 'viem';
 
@@ -40,7 +40,7 @@ import { ERROR_CODE, invariant } from '../common/utils/sdk-error.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 export class LidoSDKWrap extends LidoSDKModule {
-  private static TRANSFER_SIGNATURE = toEventSignature(
+  private static TRANSFER_SIGNATURE = toEventHash(
     getAbiItem({ abi: PartialTransferEventAbi, name: 'Transfer' }),
   );
 

--- a/packages/sdk/src/wrap/wrap.ts
+++ b/packages/sdk/src/wrap/wrap.ts
@@ -9,7 +9,7 @@ import {
   TransactionReceipt,
   decodeEventLog,
   getAbiItem,
-  getEventSelector,
+  toEventSignature,
   isAddressEqual,
 } from 'viem';
 
@@ -40,7 +40,7 @@ import { ERROR_CODE, invariant } from '../common/utils/sdk-error.js';
 import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 
 export class LidoSDKWrap extends LidoSDKModule {
-  private static TRANSFER_SIGNATURE = getEventSelector(
+  private static TRANSFER_SIGNATURE = toEventSignature(
     getAbiItem({ abi: PartialTransferEventAbi, name: 'Transfer' }),
   );
 

--- a/playground/components/action/action.tsx
+++ b/playground/components/action/action.tsx
@@ -19,8 +19,8 @@ import { useWeb3 } from '@reef-knot/web3-react';
 type ActionProps<TResult> = PropsWithChildren<{
   action: () => Promise<TResult> | TResult;
   title: string;
-  renderResult?: (result: TResult) => JSX.Element;
-  renderError?: (error: SDKError) => JSX.Element;
+  renderResult?: (result: TResult) => React.JSX.Element;
+  renderError?: (error: SDKError) => React.JSX.Element;
   walletAction?: boolean;
 }>;
 

--- a/playground/pages/_app.tsx
+++ b/playground/pages/_app.tsx
@@ -3,7 +3,7 @@ import { AppProps } from 'next/app';
 import { ToastContainer, CookiesTooltip } from '@lidofinance/lido-ui';
 import Providers from 'providers';
 
-const App = (props: AppProps): JSX.Element => {
+const App = (props: AppProps): React.JSX.Element => {
   const { Component, pageProps } = props;
 
   return <Component {...pageProps} />;
@@ -11,7 +11,7 @@ const App = (props: AppProps): JSX.Element => {
 
 const MemoApp = memo(App);
 
-const AppWrapper = (props: AppProps): JSX.Element => {
+const AppWrapper = (props: AppProps): React.JSX.Element => {
   return (
     <Providers>
       <MemoApp {...props} />

--- a/playground/pages/_document.tsx
+++ b/playground/pages/_document.tsx
@@ -61,7 +61,7 @@ export default class MyDocument extends Document {
     return `${host}/lido-preview.png`;
   }
 
-  render(): JSX.Element {
+  render(): React.JSX.Element {
     return (
       <Html lang="en">
         <Head>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1761,7 +1761,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0":
+"@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.4.0
   resolution: "@eslint-community/eslint-utils@npm:4.4.0"
   dependencies:
@@ -5111,7 +5111,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.12, @types/json-schema@npm:^7.0.8, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 97ed0cb44d4070aecea772b7b2e2ed971e10c81ec87dd4ecc160322ffa55ff330dace1793489540e3e318d90942064bb697cc0f8989391797792d919737b3b98
@@ -5264,6 +5264,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/semver@npm:^7.5.0":
+  version: 7.5.8
+  resolution: "@types/semver@npm:7.5.8"
+  checksum: ea6f5276f5b84c55921785a3a27a3cd37afee0111dfe2bcb3e03c31819c197c782598f17f0b150a69d453c9584cd14c4c4d7b9a55d2c5e6cacd4d66fdb3b3663
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.3
   resolution: "@types/stack-utils@npm:2.0.3"
@@ -5356,6 +5363,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/scope-manager@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/visitor-keys": 6.21.0
+  checksum: 71028b757da9694528c4c3294a96cc80bc7d396e383a405eab3bc224cda7341b88e0fc292120b35d3f31f47beac69f7083196c70616434072fbcd3d3e62d3376
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/type-utils@npm:5.62.0"
@@ -5380,6 +5397,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/types@npm:6.21.0"
+  checksum: 9501b47d7403417af95fc1fb72b2038c5ac46feac0e1598a46bcb43e56a606c387e9dcd8a2a0abe174c91b509f2d2a8078b093786219eb9a01ab2fbf9ee7b684
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/typescript-estree@npm:5.62.0"
@@ -5395,6 +5419,25 @@ __metadata:
     typescript:
       optional: true
   checksum: 3624520abb5807ed8f57b1197e61c7b1ed770c56dfcaca66372d584ff50175225798bccb701f7ef129d62c5989070e1ee3a0aa2d84e56d9524dcf011a2bb1a52
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/typescript-estree@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/visitor-keys": 6.21.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    minimatch: 9.0.3
+    semver: ^7.5.4
+    ts-api-utils: ^1.0.1
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: dec02dc107c4a541e14fb0c96148f3764b92117c3b635db3a577b5a56fc48df7a556fa853fb82b07c0663b4bf2c484c9f245c28ba3e17e5cb0918ea4cab2ea21
   languageName: node
   linkType: hard
 
@@ -5416,6 +5459,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^6.0.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/utils@npm:6.21.0"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.4.0
+    "@types/json-schema": ^7.0.12
+    "@types/semver": ^7.5.0
+    "@typescript-eslint/scope-manager": 6.21.0
+    "@typescript-eslint/types": 6.21.0
+    "@typescript-eslint/typescript-estree": 6.21.0
+    semver: ^7.5.4
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+  checksum: b129b3a4aebec8468259f4589985cb59ea808afbfdb9c54f02fad11e17d185e2bf72bb332f7c36ec3c09b31f18fc41368678b076323e6e019d06f74ee93f7bf2
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.62.0":
   version: 5.62.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.62.0"
@@ -5423,6 +5483,16 @@ __metadata:
     "@typescript-eslint/types": 5.62.0
     eslint-visitor-keys: ^3.3.0
   checksum: 976b05d103fe8335bef5c93ad3f76d781e3ce50329c0243ee0f00c0fcfb186c81df50e64bfdd34970148113f8ade90887f53e3c4938183afba830b4ba8e30a35
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:6.21.0":
+  version: 6.21.0
+  resolution: "@typescript-eslint/visitor-keys@npm:6.21.0"
+  dependencies:
+    "@typescript-eslint/types": 6.21.0
+    eslint-visitor-keys: ^3.4.1
+  checksum: 67c7e6003d5af042d8703d11538fca9d76899f0119130b373402819ae43f0bc90d18656aa7add25a24427ccf1a0efd0804157ba83b0d4e145f06107d7d1b7433
   languageName: node
   linkType: hard
 
@@ -8501,6 +8571,20 @@ __metadata:
     eslint:
       optional: true
   checksum: 74c6dfea7641ebcfe174be61168541a11a14aa8d72e515f5f09af55cd0d0862686104b0524aa4b8e0ce66418a44aa38a94d2588743db5fd07a6b49ffd16921d2
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-deprecation@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "eslint-plugin-deprecation@npm:2.0.0"
+  dependencies:
+    "@typescript-eslint/utils": ^6.0.0
+    tslib: ^2.3.1
+    tsutils: ^3.21.0
+  peerDependencies:
+    eslint: ^7.0.0 || ^8.0.0
+    typescript: ^4.2.4 || ^5.0.0
+  checksum: d79611e902ac419a21e51eab582fcdbcf8170aff820c5e5197e7d242e7ca6bda59c0077d88404970c25993017398dd65c96df7d31a833e332d45dd330935324b
   languageName: node
   linkType: hard
 
@@ -11741,6 +11825,7 @@ __metadata:
     eslint-config-prettier: ^8.5.0
     eslint-import-resolver-node: ^0.3.6
     eslint-import-resolver-typescript: ^3
+    eslint-plugin-deprecation: ^2.0.0
     eslint-plugin-eslint-comments: ^3
     eslint-plugin-import: ^2
     eslint-plugin-jest: ^27
@@ -12430,6 +12515,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:9.0.3, minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
@@ -12445,15 +12539,6 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 7564208ef81d7065a370f788d337cd80a689e981042cb9a1d0e6580b6c6a8c9279eba80010516e258835a988363f99f54a6f711a315089b8b42694f5da9d0d77
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3":
-  version: 9.0.3
-  resolution: "minimatch@npm:9.0.3"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
   languageName: node
   linkType: hard
 
@@ -15995,6 +16080,15 @@ __metadata:
   version: 3.0.1
   resolution: "trim-newlines@npm:3.0.1"
   checksum: b530f3fadf78e570cf3c761fb74fef655beff6b0f84b29209bac6c9622db75ad1417f4a7b5d54c96605dcd72734ad44526fef9f396807b90839449eb543c6206
+  languageName: node
+  linkType: hard
+
+"ts-api-utils@npm:^1.0.1":
+  version: 1.3.0
+  resolution: "ts-api-utils@npm:1.3.0"
+  peerDependencies:
+    typescript: ">=4.2.0"
+  checksum: c746ddabfdffbf16cb0b0db32bb287236a19e583057f8649ee7c49995bb776e1d3ef384685181c11a1a480369e022ca97512cb08c517b2d2bd82c83754c97012
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Description


- fixed edge-case in `withdraw.views.findCheckpointHints` where last finalized request would fail assertion with `Cannot find hints for unfinalized request...`
- subsequently fixed same error in `withdraw.request-info`, `withdraw.claim` modules
- added tests for this edgecase
- added eslint rule to warn on TS deprecations
- fixed deprecations warning for whole project


### Testing notes

Error was in incorrect check (less vs less or equal) if your request was finalized last(request id is `lastFinilizedRequestId`).
 To repeat this edgecase go to etherscan -> wq contract -> `lastFinilizedRequestId` and in sdk playground run `withdraw.views`, `withdraw.request-info` methods for this id

### Checklist:

- [x]  Checked the changes locally.
- [x]  Created/updated unit tests.
- [ ]  Created/updated README.md.

