### PR TITLE
Fix publish-dry-run workflow

### DIFF
--- a/.github/workflows/publish-dry-run.yml
+++ b/.github/workflows/publish-dry-run.yml
@@ -7,6 +7,10 @@ on:
         description: 'NPM token'
         required: true
 
+permissions:
+  contents: write # to be able to publish a GitHub release
+  id-token: write # to enable use of OIDC for npm provenance
+
 jobs:
   publish-dry-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
Should fix `EGITNOPERMISSION Cannot push to the Git repository.` error.
See https://github.com/lidofinance/lido-ethereum-sdk/actions/runs/13720467400/job/38374642923

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

