### PR TITLE
Copy Unichain and Unichain Sepolia definitions to sdk

### DIFF
--- a/packages/sdk/src/common/chains/unichain-sepolia.ts
+++ b/packages/sdk/src/common/chains/unichain-sepolia.ts
@@ -1,0 +1,58 @@
+import { defineChain } from 'viem';
+import { chainConfig } from 'viem/op-stack';
+
+// TODO: replace with import from 'viem/chains'
+// Copy-pasted from
+// https://github.com/wevm/viem/blob/c52c8ed2a2e18d1e0d433fe87990bc5539d579be/src/chains/definitions/unichainSepolia.ts
+// Reason: we had to downgrade viem to 2.22.23 because of the critical issue with Safe
+// But viem v2.22.23 doesn't have Unichain support, so Unichain is defined here.
+// viem v2.23.1 added Unichain support
+
+const sourceId = 11_155_111; // sepolia
+
+export const unichainSepolia = defineChain({
+  ...chainConfig,
+  id: 1301,
+  name: 'Unichain Sepolia',
+  nativeCurrency: {
+    name: 'Ether',
+    symbol: 'ETH',
+    decimals: 18,
+  },
+  rpcUrls: {
+    default: {
+      http: ['https://sepolia.unichain.org'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Uniscan',
+      url: 'https://sepolia.uniscan.xyz',
+      apiUrl: 'https://api-sepolia.uniscan.xyz/api',
+    },
+  },
+  contracts: {
+    ...chainConfig.contracts,
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 0,
+    },
+    portal: {
+      [sourceId]: {
+        address: '0x0d83dab629f0e0F9d36c0Cbc89B69a489f0751bD',
+      },
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: '0xea58fcA6849d79EAd1f26608855c2D6407d54Ce2',
+      },
+    },
+    disputeGameFactory: {
+      [sourceId]: {
+        address: '0xeff73e5aa3B9AEC32c659Aa3E00444d20a84394b',
+      },
+    },
+  },
+  testnet: true,
+  sourceId,
+});

--- a/packages/sdk/src/common/chains/unichain.ts
+++ b/packages/sdk/src/common/chains/unichain.ts
@@ -1,0 +1,53 @@
+import { defineChain } from 'viem';
+import { chainConfig } from 'viem/op-stack';
+
+// TODO: replace with import from 'viem/chains'
+// Copy-pasted from
+// https://github.com/wevm/viem/blob/c52c8ed2a2e18d1e0d433fe87990bc5539d579be/src/chains/definitions/unichain.ts
+// Reason: we had to downgrade viem to 2.22.23 because of the critical issue with Safe
+// But viem v2.22.23 doesn't have Unichain support, so Unichain is defined here.
+// viem v2.23.1 added Unichain support
+
+const sourceId = 1; // mainnet
+
+export const unichain = defineChain({
+  ...chainConfig,
+  id: 130,
+  name: 'Unichain',
+  nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ['https://mainnet.unichain.org/'],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: 'Uniscan',
+      url: 'https://uniscan.xyz',
+      apiUrl: 'https://api.uniscan.xyz/api',
+    },
+  },
+  contracts: {
+    ...chainConfig.contracts,
+    multicall3: {
+      address: '0xca11bde05977b3631167028862be2a173976ca11',
+      blockCreated: 0,
+    },
+    disputeGameFactory: {
+      [sourceId]: {
+        address: '0x2F12d621a16e2d3285929C9996f478508951dFe4',
+      },
+    },
+    portal: {
+      [sourceId]: {
+        address: '0x0bd48f6B86a26D3a217d0Fa6FfE2B491B956A7a2',
+      },
+    },
+    l1StandardBridge: {
+      [sourceId]: {
+        address: '0x81014F44b0a345033bB2b3B21C7a1A308B35fEeA',
+      },
+    },
+  },
+  sourceId,
+});

--- a/packages/sdk/src/common/constants.ts
+++ b/packages/sdk/src/common/constants.ts
@@ -7,9 +7,9 @@ import {
   optimism,
   soneiumMinato,
   soneium,
-  unichain,
-  unichainSepolia,
 } from 'viem/chains';
+import { unichain } from './chains/unichain.js';
+import { unichainSepolia } from './chains/unichain-sepolia.js';
 
 export enum CHAINS {
   Mainnet = 1,


### PR DESCRIPTION
### Description
We have to downgrade viem to v2.22.23 on the ETH Stake Widget, but this version doesn't contain Unichain support.
This PR copies Unichain and Unichain Sepolia definitions from viem 2.23 to the sdk, so we could use viem 2.22 and have Unichain support.

Related to this issue: https://github.com/safe-global/safe-apps-sdk/issues/630

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

