### PR TITLE
fix: update Hoodi RPC URL to new endpoint

### DIFF
--- a/packages/sdk/src/common/chains/hoodi.ts
+++ b/packages/sdk/src/common/chains/hoodi.ts
@@ -6,7 +6,7 @@ export const hoodi = defineChain({
   nativeCurrency: { name: 'Hoodi Ether', symbol: 'ETH', decimals: 18 },
   rpcUrls: {
     default: {
-      http: ['https://rpc.hoodi.ethpandaops.io'],
+      http: ['https://hoodi.drpc.org'],
     },
   },
   blockExplorers: {


### PR DESCRIPTION
### Description

* [`packages/sdk/src/common/chains/hoodi.ts`](diffhunk://#diff-8f2273c600940b9bc895de5afd89d5aa672ece2d6a8c65c0c5e867145bd35afaL9-R9): Updated the `rpcUrls` default HTTP URL from `https://rpc.hoodi.ethpandaops.io` to `https://hoodi.drpc.org`.

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

