### PR TITLE
feat(DG): make DG getGovernanceWarningStatus return supportPercent in…

### DIFF
--- a/packages/sdk/src/dual-governance/__tests__/dual-governance.test.ts
+++ b/packages/sdk/src/dual-governance/__tests__/dual-governance.test.ts
@@ -390,7 +390,7 @@ describe('LidoSDKDualGovernance - getGovernanceWarningStatus', () => {
 
     expect(result).toEqual({
       state: 'Blocked',
-      currentVetoSupportPercent: null,
+      currentVetoSupportPercent: 60,
     });
   });
 
@@ -405,7 +405,7 @@ describe('LidoSDKDualGovernance - getGovernanceWarningStatus', () => {
 
     expect(result).toEqual({
       state: 'Blocked',
-      currentVetoSupportPercent: null,
+      currentVetoSupportPercent: 60,
     });
   });
 
@@ -418,7 +418,7 @@ describe('LidoSDKDualGovernance - getGovernanceWarningStatus', () => {
 
     expect(result).toEqual({
       state: 'Blocked',
-      currentVetoSupportPercent: null,
+      currentVetoSupportPercent: 60,
     });
   });
 

--- a/packages/sdk/src/dual-governance/dual-governance.ts
+++ b/packages/sdk/src/dual-governance/dual-governance.ts
@@ -289,6 +289,8 @@ export class LidoSDKDualGovernance extends LidoSDKModule {
     triggerPercent,
   }: GetGovernanceWarningStatusProps): Promise<GetGovernanceWarningStatusReturnType> {
     const currentGovernanceState = await this.getDualGovernanceState();
+    const { currentSupportPercent } =
+      await this.calculateCurrentVetoSignallingThresholdProgress();
 
     const NORMAL_STATES = [
       GovernanceState.Normal,
@@ -303,14 +305,11 @@ export class LidoSDKDualGovernance extends LidoSDKModule {
     if (BLOCKED_STATES.includes(currentGovernanceState)) {
       return {
         state: 'Blocked',
-        currentVetoSupportPercent: null,
+        currentVetoSupportPercent: currentSupportPercent,
       };
     }
 
     if (NORMAL_STATES.includes(currentGovernanceState)) {
-      const { currentSupportPercent } =
-        await this.calculateCurrentVetoSignallingThresholdProgress();
-
       if (currentSupportPercent > triggerPercent) {
         return {
           state: 'Warning',


### PR DESCRIPTION
… Blocked state

### Description

Initial version of the `getGovernanceWarningStatus` method of the DualGovernance module wasn't returning calculated `currentSupportPercent` for the 'Blocked' state. 

This PR adjusts return value and tests of the `getGovernanceWarningStatus` method. 

<!--- If any section below doesn't make sense for your pull request, delete it please. -->

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

