### PR TITLE
fix: rename escrow to escrowAbi and update exports in dual-governance…

### DIFF
--- a/packages/sdk/src/dual-governance/abi/Escrow.ts
+++ b/packages/sdk/src/dual-governance/abi/Escrow.ts
@@ -1,4 +1,4 @@
-export const escrow = [
+export const escrowAbi = [
   {
     inputs: [],
     name: 'ST_ETH',

--- a/packages/sdk/src/dual-governance/dual-governance.ts
+++ b/packages/sdk/src/dual-governance/dual-governance.ts
@@ -15,7 +15,7 @@ import { LidoSDKModule } from '../common/class-primitives/sdk-module.js';
 import { Cache, Logger } from '../common/decorators/index.js';
 
 import { dualGovernanceAbi } from './abi/DualGovernance.js';
-import { escrow } from './abi/Escrow.js';
+import { escrowAbi } from './abi/Escrow.js';
 import { emergencyProtectedTimelockAbi } from './abi/EmergencyProtectedTimelock.js';
 import { stETH } from './abi/StETH.js';
 import { dgConfigProviderAbi } from './abi/DGConfigProvider.js';
@@ -82,7 +82,7 @@ export class LidoSDKDualGovernance extends LidoSDKModule {
   @Logger('Contracts:')
   @Cache(30 * 60 * 1000, ['core.chain.id'])
   public async getContractVetoSignallingEscrow(): Promise<
-    GetContractReturnType<typeof escrow, PublicClient>
+    GetContractReturnType<typeof escrowAbi, PublicClient>
   > {
     const address = await this.getVetoSignallingEscrowAddress();
 
@@ -94,7 +94,7 @@ export class LidoSDKDualGovernance extends LidoSDKModule {
 
     return getContract({
       address,
-      abi: escrow,
+      abi: escrowAbi,
       client: this.core.rpcProvider,
     });
   }

--- a/packages/sdk/src/dual-governance/index.ts
+++ b/packages/sdk/src/dual-governance/index.ts
@@ -1,1 +1,14 @@
-export { LidoSDKDualGovernance } from './dual-governance.js'
+export { escrowAbi } from './abi/Escrow.js';
+export { emergencyProtectedTimelockAbi } from './abi/EmergencyProtectedTimelock.js';
+export { dgConfigProviderAbi } from './abi/DGConfigProvider.js';
+export { dualGovernanceAbi } from './abi/DualGovernance.js';
+export { LidoSDKDualGovernance } from './dual-governance.js';
+
+export type {
+  GovernanceState,
+  GetGovernanceWarningStatusProps,
+  GetGovernanceWarningStatusReturnType,
+  DualGovernanceState,
+  SignallingEscrowDetails,
+  DualGovernanceConfig,
+} from './types.js';


### PR DESCRIPTION
### Description

**ABI Naming and Usage Updates:**

* Renamed the Escrow contract ABI from `escrow` to `escrowAbi` in `Escrow.ts` to follow naming conventions and improve clarity.
* Updated all references to the Escrow ABI in `dual-governance.ts` to use `escrowAbi` instead of `escrow`, ensuring consistency in contract interactions. [[1]](diffhunk://#diff-328cd4f14c9642a210abd37869c864bc82405b111cdcda47796ed40c6148fab8L18-R18) [[2]](diffhunk://#diff-328cd4f14c9642a210abd37869c864bc82405b111cdcda47796ed40c6148fab8L85-R85) [[3]](diffhunk://#diff-328cd4f14c9642a210abd37869c864bc82405b111cdcda47796ed40c6148fab8L97-R97)

**Public API Improvements:**

* Enhanced the `index.ts` export surface by re-exporting the main contract ABIs (`escrowAbi`, `emergencyProtectedTimelockAbi`, `dgConfigProviderAbi`, `dualGovernanceAbi`) and relevant types for easier external usage.

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

