### PR TITLE
test: migrate to vitest, replace ganache with anvil, add stvault tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Check types
         run: yarn types
 
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
       - name: Tests
         run: yarn test
         env:

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -161,7 +161,8 @@
     "build:cjs": "tsc --project tsconfig.build.json --module commonjs --moduleResolution node10 --outDir ./dist/cjs --removeComments --verbatimModuleSyntax false && echo > ./dist/cjs/package.json '{\"type\":\"commonjs\"}'",
     "build:esm": "tsc --project tsconfig.build.json --module nodenext --outDir ./dist/esm && echo > ./dist/esm/package.json '{\"type\":\"module\",\"sideEffects\":false}'",
     "build:types": "tsc --project tsconfig.build.json --module nodenext --declarationDir ./dist/types --emitDeclarationOnly --declaration --declarationMap",
-    "test": "jest",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "prepublishOnly": "node scripts/updateVersion.cjs",
     "lint": "eslint . --ext .ts --max-warnings 0",
     "clean": "rimraf dist"
@@ -178,14 +179,12 @@
     "viem": "^2.45.0"
   },
   "devDependencies": {
-    "@jest/globals": "^29.7.0",
     "@types/fs-extra": "^11.0.1",
+    "@viem/anvil": "^0.0.10",
     "dotenv": "^16.3.1",
     "fs-extra": "^11.1.1",
-    "ganache": "^7.9.2",
-    "jest": "^29.7.0",
     "rimraf": "^5.0.1",
-    "ts-jest": "^29.1.2",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^2.1.0"
   }
 }

--- a/packages/sdk/src/common/utils/__tests__/bigint-math.test.ts
+++ b/packages/sdk/src/common/utils/__tests__/bigint-math.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test } from 'vitest';
 import { bigIntCeilDiv } from '../bigint-math.js';
 
 describe('bigIntCeilDiv', () => {

--- a/packages/sdk/src/core/__tests__/core-wallet.test.ts
+++ b/packages/sdk/src/core/__tests__/core-wallet.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe, jest } from '@jest/globals';
+import { test, expect, describe, vi } from 'vitest';
 
 import {
   useRpcCore,
@@ -178,7 +178,7 @@ describe('Account hoisting', () => {
   });
 
   test('useAccount requests account from walletClient', async () => {
-    const mockFn = jest.fn();
+    const mockFn = vi.fn();
     const mockTransport = useMockTransport(async (args, originalRequest) => {
       mockFn(args.method);
       if (args.method === 'eth_requestAccounts') {
@@ -217,7 +217,7 @@ describe('Perform Transaction', () => {
   const testHash = '0xaaaaaabbbbbbb';
 
   testSpending('perform transaction works with EOA', async () => {
-    const mockTransportCallback = jest.fn<MockTransportCallback>((_, next) =>
+    const mockTransportCallback = vi.fn<MockTransportCallback>((_, next) =>
       next(),
     );
     const core = createCore(
@@ -230,17 +230,17 @@ describe('Perform Transaction', () => {
     const stake = new LidoSDKStake({ core });
     const rawContract = await stake.getContractStETH();
 
-    const mockGetGasLimit = jest.fn<PerformTransactionGasLimit>((options) =>
+    const mockGetGasLimit = vi.fn<PerformTransactionGasLimit>((options) =>
       rawContract.estimateGas.submit([zeroAddress], {
         ...options,
         value,
       }),
     );
-    const mockSendTransaction = jest.fn<PerformTransactionSendTransaction>(
+    const mockSendTransaction = vi.fn<PerformTransactionSendTransaction>(
       (options) =>
         rawContract.write.submit([zeroAddress], { ...options, value }),
     );
-    const mockTxCallback = jest.fn<TransactionCallback>();
+    const mockTxCallback = vi.fn<TransactionCallback>();
 
     const txResult = await core.performTransaction({
       getGasLimit: mockGetGasLimit,
@@ -275,7 +275,7 @@ describe('Perform Transaction', () => {
   });
 
   testSpending('perform transaction works with Multisig', async () => {
-    const mockTransportCallback = jest.fn<MockTransportCallback>(
+    const mockTransportCallback = vi.fn<MockTransportCallback>(
       async (args, next) => {
         if (args.method === 'eth_sendTransaction') {
           return testHash;
@@ -294,17 +294,17 @@ describe('Perform Transaction', () => {
     const stake = new LidoSDKStake({ core });
     const rawContract = await stake.getContractStETH();
 
-    const mockGetGasLimit = jest.fn<PerformTransactionGasLimit>((options) =>
+    const mockGetGasLimit = vi.fn<PerformTransactionGasLimit>((options) =>
       rawContract.estimateGas.submit([zeroAddress], {
         ...options,
         value,
       }),
     );
-    const mockSendTransaction = jest.fn<PerformTransactionSendTransaction>(
+    const mockSendTransaction = vi.fn<PerformTransactionSendTransaction>(
       (options) =>
         rawContract.write.submit([zeroAddress], { ...options, value }),
     );
-    const mockTxCallback = jest.fn<TransactionCallback>();
+    const mockTxCallback = vi.fn<TransactionCallback>();
 
     const txResult = await core.performTransaction({
       getGasLimit: mockGetGasLimit,

--- a/packages/sdk/src/core/__tests__/core.test.ts
+++ b/packages/sdk/src/core/__tests__/core.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/expect-expect */
-import { test, expect, describe } from '@jest/globals';
+import { test, expect, describe } from 'vitest';
 
 import { LidoSDKCore } from '../index.js';
 import { useTestsEnvs } from '../../../tests/utils/fixtures/use-test-envs.js';
@@ -123,10 +123,16 @@ describe('Core Tests', () => {
   });
 
   test('toBlockNumber', async () => {
-    const block = await rpcCore.publicClient.getBlock({ blockTag: 'latest' });
-    await expect(rpcCore.toBlockNumber({ block: block.number })).resolves.toBe(
-      block.number,
+    const latest = await rpcCore.publicClient.getBlock({ blockTag: 'latest' });
+    await expect(rpcCore.toBlockNumber({ block: latest.number })).resolves.toBe(
+      latest.number,
     );
+    // Use a block well behind 'latest' to avoid Anvil-mined blocks that share
+    // a timestamp with their predecessor (automining assigns timestamp = prev+1
+    // which can duplicate timestamps already present on the fork).
+    const block = await rpcCore.publicClient.getBlock({
+      blockNumber: latest.number - 200n,
+    });
     await expect(
       rpcCore.toBlockNumber({ timestamp: block.timestamp }),
     ).resolves.toBe(block.number);

--- a/packages/sdk/src/core/__tests__/get-block-by-timestamp.test.ts
+++ b/packages/sdk/src/core/__tests__/get-block-by-timestamp.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test } from 'vitest';
 import { useRpcCore } from '../../../tests/utils/fixtures/use-core.js';
 import { expectPositiveBn } from '../../../tests/utils/expect/expect-bn.js';
 

--- a/packages/sdk/src/dual-governance/__tests__/dual-governance.test.ts
+++ b/packages/sdk/src/dual-governance/__tests__/dual-governance.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-conditional-expect */
-import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+import { beforeEach, describe, expect, vi, test } from 'vitest';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
 import { LidoSDKDualGovernance } from '../../index.js';
 import { useDualGovernance } from '../../../tests/utils/fixtures/use-dual-governance.js';
@@ -208,7 +208,7 @@ describe('LidoSDKDualGovernance - calculateCurrentVetoSignallingThresholdProgres
   };
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
     dualGovernance = new LidoSDKDualGovernance({
       core: { chain: { id: 560048, name: 'Hoodi' } } as any,
     });
@@ -219,19 +219,19 @@ describe('LidoSDKDualGovernance - calculateCurrentVetoSignallingThresholdProgres
     escrow: bigint,
     supply: bigint,
   ) => {
-    jest
-      .spyOn(dualGovernance, 'getDualGovernanceConfig')
-      .mockResolvedValue(config);
+    vi.spyOn(dualGovernance, 'getDualGovernanceConfig').mockResolvedValue(
+      config,
+    );
 
     if (escrow === null) {
-      jest.spyOn(dualGovernance, 'getTotalStEthInEscrow').mockResolvedValue(0n);
+      vi.spyOn(dualGovernance, 'getTotalStEthInEscrow').mockResolvedValue(0n);
     } else {
-      jest
-        .spyOn(dualGovernance, 'getTotalStEthInEscrow')
-        .mockResolvedValue(escrow);
+      vi.spyOn(dualGovernance, 'getTotalStEthInEscrow').mockResolvedValue(
+        escrow,
+      );
     }
 
-    jest.spyOn(dualGovernance, 'getTotalStETHSupply').mockResolvedValue(supply);
+    vi.spyOn(dualGovernance, 'getTotalStETHSupply').mockResolvedValue(supply);
   };
 
   test('calculates progress correctly for normal case', async () => {
@@ -323,16 +323,16 @@ describe('LidoSDKDualGovernance - getDualGovernanceState', () => {
   let dualGovernance: LidoSDKDualGovernance;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
     dualGovernance = new LidoSDKDualGovernance({
       core: { chain: { id: 560048, name: 'Hoodi' } },
     } as any);
   });
 
   const mockGetContractDualGovernance = (returnValue: DualGovernanceState) => {
-    jest.spyOn(dualGovernance, 'getContractDualGovernance').mockResolvedValue({
+    vi.spyOn(dualGovernance, 'getContractDualGovernance').mockResolvedValue({
       read: {
-        getStateDetails: jest
+        getStateDetails: vi
           .fn()
           .mockImplementation(() => Promise.resolve(returnValue)),
       } as any,
@@ -363,7 +363,7 @@ describe('LidoSDKDualGovernance - getGovernanceWarningStatus', () => {
   let dualGovernance: LidoSDKDualGovernance;
 
   beforeEach(() => {
-    jest.resetAllMocks();
+    vi.resetAllMocks();
     dualGovernance = new LidoSDKDualGovernance({
       core: { chain: { id: 560048, name: 'Hoodi' } },
     } as any);
@@ -373,12 +373,13 @@ describe('LidoSDKDualGovernance - getGovernanceWarningStatus', () => {
     governanceState: GovernanceState,
     vetoSignalingProgress: { currentSupportPercent: number },
   ) => {
-    jest
-      .spyOn(dualGovernance, 'getDualGovernanceState')
-      .mockResolvedValue(governanceState);
-    jest
-      .spyOn(dualGovernance, 'calculateCurrentVetoSignallingThresholdProgress')
-      .mockResolvedValue(vetoSignalingProgress);
+    vi.spyOn(dualGovernance, 'getDualGovernanceState').mockResolvedValue(
+      governanceState,
+    );
+    vi.spyOn(
+      dualGovernance,
+      'calculateCurrentVetoSignallingThresholdProgress',
+    ).mockResolvedValue(vetoSignalingProgress);
   };
 
   test('returns "Blocked" state when in VetoSignalling', async () => {

--- a/packages/sdk/src/erc20/__tests__/steth-wallet.test.ts
+++ b/packages/sdk/src/erc20/__tests__/steth-wallet.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe } from '@jest/globals';
+import { beforeAll, describe } from 'vitest';
 import { LidoSDKstETH } from '../steth.js';
 import {
   useRpcCore,

--- a/packages/sdk/src/erc20/__tests__/steth.test.ts
+++ b/packages/sdk/src/erc20/__tests__/steth.test.ts
@@ -1,4 +1,4 @@
-import { describe } from '@jest/globals';
+import { describe } from 'vitest';
 import { LidoSDKstETH } from '../steth.js';
 import {
   useRpcCore,

--- a/packages/sdk/src/erc20/__tests__/wsteth-wallet.test.ts
+++ b/packages/sdk/src/erc20/__tests__/wsteth-wallet.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe } from '@jest/globals';
+import { beforeAll, describe } from 'vitest';
 import { LidoSDKwstETH } from '../wsteth.js';
 import {
   useRpcCore,

--- a/packages/sdk/src/erc20/__tests__/wsteth.test.ts
+++ b/packages/sdk/src/erc20/__tests__/wsteth.test.ts
@@ -1,4 +1,4 @@
-import { describe } from '@jest/globals';
+import { describe } from 'vitest';
 import { LidoSDKwstETH } from '../wsteth.js';
 import {
   useRpcCore,

--- a/packages/sdk/src/events/__tests__/events.test.ts
+++ b/packages/sdk/src/events/__tests__/events.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll } from '@jest/globals';
+import { describe, test, expect, beforeAll } from 'vitest';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
 import { LidoSDKEvents } from '../events.js';
 import { LidoSDKStethEvents } from '../steth-events.js';

--- a/packages/sdk/src/l2/__test__/l2.test.ts
+++ b/packages/sdk/src/l2/__test__/l2.test.ts
@@ -62,8 +62,6 @@ const prepareL2Wsteth = async () => {
 
   await testClient.impersonateAccount({ address: bridge });
 
-  // TestClient<'anvil'> lacks walletActions, so use a dedicated WalletClient
-  // for the impersonated bridge account to call writeContract.
   const bridgeWalletClient = createWalletClient({
     account: bridge,
     chain: testClient.chain,
@@ -75,6 +73,7 @@ const prepareL2Wsteth = async () => {
     address: wstethAddress,
     functionName: 'bridgeMint',
     args: [account.address, 2000n],
+    chain: testClient.chain,
   });
 };
 

--- a/packages/sdk/src/l2/__test__/l2.test.ts
+++ b/packages/sdk/src/l2/__test__/l2.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, jest, test } from '@jest/globals';
+import { beforeAll, describe, expect, vi, test } from 'vitest';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
 import {
   useL2,
@@ -14,7 +14,7 @@ import {
   useAccount,
   useAltAccount,
 } from '../../../tests/utils/fixtures/use-wallet-client.js';
-import { getContract } from 'viem';
+import { getContract, createWalletClient, custom, parseEther } from 'viem';
 import { bridgedWstethAbi } from '../abi/brigedWsteth.js';
 import { expectAddress } from '../../../tests/utils/expect/expect-address.js';
 import { expectContract } from '../../../tests/utils/expect/expect-contract.js';
@@ -48,29 +48,33 @@ const prepareL2Wsteth = async () => {
 
   const bridge = await wstethImpersonated.read.bridge();
 
+  // Use generous ETH balances so eth_estimateGas passes even with mainnet-level
+  // maxFeePerGas filled in by prepareTransactionRequest (0.0001 ETH is not enough).
   await testClient.setBalance({
     address: account.address,
-    value: 100000000000000n,
+    value: parseEther('10'),
   });
 
   await testClient.setBalance({
     address: bridge,
-    value: 100000000000000n,
+    value: parseEther('1'),
   });
 
-  await testClient.request({
-    method: 'evm_addAccount' as any,
-    params: [bridge, 'pass'],
-  });
+  await testClient.impersonateAccount({ address: bridge });
 
-  await testClient.request({
-    method: 'personal_unlockAccount' as any,
-    params: [bridge, 'pass'],
-  });
-
-  await wstethImpersonated.write.bridgeMint([account.address, 2000n], {
+  // TestClient<'anvil'> lacks walletActions, so use a dedicated WalletClient
+  // for the impersonated bridge account to call writeContract.
+  const bridgeWalletClient = createWalletClient({
     account: bridge,
     chain: testClient.chain,
+    transport: custom({ request: testClient.request }),
+  });
+
+  await bridgeWalletClient.writeContract({
+    abi: bridgedWstethAbi,
+    address: wstethAddress,
+    functionName: 'bridgeMint',
+    args: [account.address, 2000n],
   });
 };
 
@@ -123,7 +127,7 @@ describe('LidoSDKL2 wrap', () => {
   beforeAll(prepareL2Wsteth);
 
   testSpending('set allowance', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await l2.approveWstethForWrap({ value, callback: mock });
     expectTxCallback(mock, tx);
     await expect(l2.getWstethForWrapAllowance(account)).resolves.toEqual(value);
@@ -157,7 +161,7 @@ describe('LidoSDKL2 wrap', () => {
     const stethValue = await l2.steth.convertToSteth(value);
     const stethBalanceBefore = await l2.steth.balance(account.address);
     const wstethBalanceBefore = await l2.wsteth.balance(account.address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await l2.wrapWstethToSteth({ value, callback: mock });
     expectTxCallback(mock, tx);
     const stethBalanceAfter = await l2.steth.balance(account.address);
@@ -208,7 +212,7 @@ describe('LidoSDKL2 wrap', () => {
     const stethValue = await l2.steth.convertToSteth(value);
     const stethBalanceBefore = await l2.steth.balance(account.address);
     const wstethBalanceBefore = await l2.wsteth.balance(account.address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await l2.unwrapStethToWsteth({
       value: stethValue,
       callback: mock,
@@ -336,7 +340,7 @@ describe('LidoSDKL2Steth shares', () => {
       const amountSteth = await l2.steth.convertToSteth(amount);
       const balanceStethBefore = await l2.steth.balance(account.address);
       const balanceSharesBefore = await l2.steth.balanceShares(account.address);
-      const mockTxCallback = jest.fn<TransactionCallback>();
+      const mockTxCallback = vi.fn<TransactionCallback>();
 
       const tx = await l2.steth.transferShares({
         amount,

--- a/packages/sdk/src/rewards/__tests__/rewards.test.ts
+++ b/packages/sdk/src/rewards/__tests__/rewards.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-conditional-expect */
-import { describe, test } from '@jest/globals';
+import { describe, test } from 'vitest';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
 import { LidoSDKRewards } from '../../index.js';
 

--- a/packages/sdk/src/shares/__tests__/shares-wallet.test.ts
+++ b/packages/sdk/src/shares/__tests__/shares-wallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, jest } from '@jest/globals';
+import { describe, expect, vi } from 'vitest';
 import { useSteth } from '../../../tests/utils/fixtures/use-steth.js';
 import {
   SPENDING_TIMEOUT,
@@ -26,7 +26,7 @@ describe('LidoSDKStake wallet methods', () => {
       const amountSteth = await shares.convertToShares(amount);
       const balanceStethBefore = await steth.balance(address);
       const balanceSharesBefore = await shares.balance(address);
-      const mockTxCallback = jest.fn<TransactionCallback>();
+      const mockTxCallback = vi.fn<TransactionCallback>();
       const tx = await shares.transfer({
         amount,
         to: alt.address,

--- a/packages/sdk/src/shares/__tests__/shares.test.ts
+++ b/packages/sdk/src/shares/__tests__/shares.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test } from 'vitest';
 import { LidoSDKShares } from '../shares.js';
 import type { BatchSharesToStethValue } from '../types.js';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';

--- a/packages/sdk/src/stake/__tests__/stake-wallet.test.ts
+++ b/packages/sdk/src/stake/__tests__/stake-wallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, jest, expect } from '@jest/globals';
+import { describe, vi, expect } from 'vitest';
 import { useStake } from '../../../tests/utils/fixtures/use-stake.js';
 import {
   SPENDING_TIMEOUT,
@@ -20,7 +20,7 @@ describe('LidoSDKStake wallet methods', () => {
       const stakeValue = 100n;
       const balanceBefore = await steth.balance();
       const balanceSharesBefore = await shares.balance();
-      const mockTxCallback = jest.fn<TransactionCallback>();
+      const mockTxCallback = vi.fn<TransactionCallback>();
       const tx = await stake.stakeEth({
         value: stakeValue,
         callback: mockTxCallback,

--- a/packages/sdk/src/stake/__tests__/stake.test.ts
+++ b/packages/sdk/src/stake/__tests__/stake.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 import { LidoSDKStake } from '../stake.js';
 import { expectAddress } from '../../../tests/utils/expect/expect-address.js';
 import { expectContract } from '../../../tests/utils/expect/expect-contract.js';

--- a/packages/sdk/src/statistics/__tests__/stats.test.ts
+++ b/packages/sdk/src/statistics/__tests__/stats.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect } from 'vitest';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
 import {
   AprRebaseEvent,

--- a/packages/sdk/src/stvault/__tests__/calculate-health.test.ts
+++ b/packages/sdk/src/stvault/__tests__/calculate-health.test.ts
@@ -1,0 +1,125 @@
+import { describe, test, expect } from 'vitest';
+import { calculateHealth } from '../utils/overview/calculate-health.js';
+
+describe('calculateHealth', () => {
+  describe('healthy vault', () => {
+    test('returns isHealthy=true when totalValue is well above liability', () => {
+      const result = calculateHealth({
+        totalValue: 100n * 10n ** 18n,
+        liabilitySharesInStethWei: 50n * 10n ** 18n,
+        forceRebalanceThresholdBP: 1000, // 10%
+      });
+
+      expect(result.isHealthy).toBe(true);
+      expect(result.healthRatio).toBeGreaterThan(100);
+    });
+
+    test('returns isHealthy=true when there is no liability', () => {
+      const result = calculateHealth({
+        totalValue: 100n * 10n ** 18n,
+        liabilitySharesInStethWei: 0n,
+        forceRebalanceThresholdBP: 1000,
+      });
+
+      expect(result.isHealthy).toBe(true);
+      expect(result.healthRatio).toBe(Infinity);
+      expect(result.healthRatio18).toBe(Infinity);
+    });
+  });
+
+  describe('unhealthy vault', () => {
+    test('returns isHealthy=false when adjusted value is below liability', () => {
+      const result = calculateHealth({
+        // totalValue * (1 - 0.5) = 50, but liability = 80 => unhealthy
+        totalValue: 100n * 10n ** 18n,
+        liabilitySharesInStethWei: 80n * 10n ** 18n,
+        forceRebalanceThresholdBP: 5000, // 50%
+      });
+
+      expect(result.isHealthy).toBe(false);
+      expect(result.healthRatio).toBeLessThan(100);
+    });
+
+    test('returns isHealthy=false when totalValue < liabilityShares', () => {
+      const result = calculateHealth({
+        totalValue: 50n * 10n ** 18n,
+        liabilitySharesInStethWei: 100n * 10n ** 18n,
+        forceRebalanceThresholdBP: 0,
+      });
+
+      expect(result.isHealthy).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('returns exact 100 healthRatio at exact threshold boundary', () => {
+      // With threshold=0: adjustedValuation = totalValue * 10000/10000 = totalValue
+      // healthRatio = totalValue/liability * 100 = 100 when equal
+      const result = calculateHealth({
+        totalValue: 100n * 10n ** 18n,
+        liabilitySharesInStethWei: 100n * 10n ** 18n,
+        forceRebalanceThresholdBP: 0,
+      });
+
+      expect(result.healthRatio).toBeCloseTo(100, 0);
+      expect(result.isHealthy).toBe(true);
+    });
+
+    test('handles zero totalValue with zero liability as Infinity', () => {
+      const result = calculateHealth({
+        totalValue: 0n,
+        liabilitySharesInStethWei: 0n,
+        forceRebalanceThresholdBP: 1000,
+      });
+
+      expect(result.healthRatio).toBe(Infinity);
+      expect(result.isHealthy).toBe(true);
+    });
+
+    test('handles zero totalValue with non-zero liability as unhealthy', () => {
+      const result = calculateHealth({
+        totalValue: 0n,
+        liabilitySharesInStethWei: 1n * 10n ** 18n,
+        forceRebalanceThresholdBP: 0,
+      });
+
+      expect(result.healthRatio).toBe(0);
+      expect(result.isHealthy).toBe(false);
+    });
+
+    test('healthRatio18 is precision-scaled version of healthRatio', () => {
+      const result = calculateHealth({
+        totalValue: 200n * 10n ** 18n,
+        liabilitySharesInStethWei: 100n * 10n ** 18n,
+        forceRebalanceThresholdBP: 0,
+      });
+
+      expect(result.healthRatio18).toBeGreaterThan(0n);
+      expect(typeof result.healthRatio18).toBe('bigint');
+      // healthRatio18 = healthRatio * 1e18
+      expect(Number(result.healthRatio18) / 1e18).toBeCloseTo(
+        result.healthRatio,
+        6,
+      );
+    });
+
+    test('large forceRebalanceThresholdBP reduces adjusted value', () => {
+      // threshold=9000 (90%) means adjustedValuation = totalValue * 10%
+      const resultHighThreshold = calculateHealth({
+        totalValue: 1000n * 10n ** 18n,
+        liabilitySharesInStethWei: 100n * 10n ** 18n,
+        forceRebalanceThresholdBP: 9000,
+      });
+
+      const resultLowThreshold = calculateHealth({
+        totalValue: 1000n * 10n ** 18n,
+        liabilitySharesInStethWei: 100n * 10n ** 18n,
+        forceRebalanceThresholdBP: 1000,
+      });
+
+      expect(resultHighThreshold.healthRatio).toBeLessThan(
+        resultLowThreshold.healthRatio,
+      );
+    });
+  });
+});

--- a/packages/sdk/src/stvault/__tests__/report-proof.test.ts
+++ b/packages/sdk/src/stvault/__tests__/report-proof.test.ts
@@ -1,0 +1,273 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import type { Address } from 'viem';
+import { StandardMerkleTree } from '@openzeppelin/merkle-tree';
+import {
+  getVaultData,
+  getReportProofByVault,
+  getReportProofs,
+} from '../utils/report-proof.js';
+import type { Report } from '../types.js';
+
+// ─── Mock IPFS fetch ──────────────────────────────────────────────────────────
+vi.mock('../utils/ipfs.js', () => ({
+  fetchIPFS: vi.fn(),
+  fetchIPFSBuffer: vi.fn(),
+  fetchIPFSVerify: vi.fn(),
+  calculateIPFSAddCID: vi.fn(),
+  IPFS_GATEWAY: 'https://ipfs.io/ipfs',
+}));
+
+import { fetchIPFS } from '../utils/ipfs.js';
+
+// ─── Test fixtures ────────────────────────────────────────────────────────────
+const VAULT_ADDRESS =
+  '0x1234567890123456789012345678901234567890' as Address;
+const VAULT_ADDRESS_2 =
+  '0x2234567890123456789012345678901234567890' as Address;
+
+const LEAF_ENCODING = [
+  'address',
+  'uint256',
+  'uint256',
+  'uint256',
+  'uint256',
+  'uint256',
+] as const satisfies Report['leafEncoding'];
+
+// Build a valid Merkle tree so that StandardMerkleTree.load() accepts the data
+const RAW_VALUES: [string, string, string, string, string, string][] = [
+  [
+    VAULT_ADDRESS,
+    '1000000000000000000',
+    '50000000000000000',
+    '500000000000000000',
+    '600000000000000000',
+    '100000000000000000',
+  ],
+  [
+    VAULT_ADDRESS_2,
+    '2000000000000000000',
+    '100000000000000000',
+    '1000000000000000000',
+    '1200000000000000000',
+    '200000000000000000',
+  ],
+];
+
+const realTree = StandardMerkleTree.of(RAW_VALUES, [...LEAF_ENCODING]);
+const treeDump = realTree.dump();
+
+// Derive expected leaf hashes from the real tree for assertions
+const vault1Entry = treeDump.values.find(
+  (v) => v.value[0]?.toLowerCase() === VAULT_ADDRESS.toLowerCase(),
+)!;
+const vault2Entry = treeDump.values.find(
+  (v) => v.value[0]?.toLowerCase() === VAULT_ADDRESS_2.toLowerCase(),
+)!;
+const EXPECTED_LEAF_1 = treeDump.tree[vault1Entry.treeIndex]!;
+const EXPECTED_LEAF_2 = treeDump.tree[vault2Entry.treeIndex]!;
+
+const MOCK_REPORT: Report = {
+  format: 'standard-v1',
+  leafEncoding: LEAF_ENCODING,
+  tree: treeDump.tree as `0x${string}`[],
+  values: treeDump.values.map(({ treeIndex, value }) => ({
+    treeIndex: BigInt(treeIndex),
+    value: value as [Address, string, string, string, string, string],
+  })),
+  refSlot: 12345,
+  timestamp: 1700000000,
+  blockNumber: 19000000n,
+  prevTreeCID: 'QmPrevCID',
+  leafIndexToData: {
+    vault_address: 0,
+    total_value_wei: 1,
+    fee: 2,
+    liability_shares: 3,
+    max_liability_shares: 4,
+    slashing_reserve: 5,
+  },
+  extraValues: {
+    [VAULT_ADDRESS]: {
+      inOutDelta: '500000000000000000',
+      prevFee: '10000000000000000',
+      infraFee: '5000000000000000',
+      liquidityFee: '3000000000000000',
+      reservationFee: '2000000000000000',
+    },
+    [VAULT_ADDRESS_2]: {
+      inOutDelta: '1000000000000000000',
+      prevFee: '20000000000000000',
+      infraFee: '10000000000000000',
+      liquidityFee: '6000000000000000',
+      reservationFee: '4000000000000000',
+    },
+  },
+};
+
+const TEST_CID = 'QmTestCID123';
+
+describe('getVaultData', () => {
+  test('extracts vault data from report correctly', () => {
+    const result = getVaultData(MOCK_REPORT, VAULT_ADDRESS, TEST_CID);
+
+    expect(result).toBeDefined();
+    expect(result.data.vaultAddress).toBe(VAULT_ADDRESS);
+    expect(result.data.totalValueWei).toBe('1000000000000000000');
+    expect(result.data.fee).toBe('50000000000000000');
+    expect(result.data.liabilityShares).toBe('500000000000000000');
+    expect(result.data.maxLiabilityShares).toBe('600000000000000000');
+    expect(result.data.slashingReserve).toBe('100000000000000000');
+  });
+
+  test('includes extra data fields', () => {
+    const result = getVaultData(MOCK_REPORT, VAULT_ADDRESS, TEST_CID);
+
+    expect(result.extraData.inOutDelta).toBe('500000000000000000');
+    expect(result.extraData.prevFee).toBe('10000000000000000');
+    expect(result.extraData.infraFee).toBe('5000000000000000');
+    expect(result.extraData.liquidityFee).toBe('3000000000000000');
+    expect(result.extraData.reservationFee).toBe('2000000000000000');
+  });
+
+  test('includes metadata fields', () => {
+    const result = getVaultData(MOCK_REPORT, VAULT_ADDRESS, TEST_CID);
+
+    expect(result.refSlot).toBe(12345);
+    expect(result.blockNumber).toBe(19000000);
+    expect(result.timestamp).toBe(1700000000);
+    expect(result.prevTreeCID).toBe('QmPrevCID');
+    expect(result.cid).toBe(TEST_CID);
+    expect(result.leaf).toBe(EXPECTED_LEAF_1);
+  });
+
+  test('works with case-insensitive vault address matching', () => {
+    const uppercaseAddress = VAULT_ADDRESS.toUpperCase() as Address;
+    const result = getVaultData(MOCK_REPORT, uppercaseAddress, TEST_CID);
+
+    expect(result.data.vaultAddress).toBe(VAULT_ADDRESS);
+  });
+
+  test('throws when vault not found in report', () => {
+    const unknownVault =
+      '0x9999999999999999999999999999999999999999' as Address;
+
+    expect(() => getVaultData(MOCK_REPORT, unknownVault, TEST_CID)).toThrow(
+      'Vault not found',
+    );
+  });
+
+  test('throws when leaf is missing from tree', () => {
+    const reportWithBadIndex: Report = {
+      ...MOCK_REPORT,
+      values: [
+        {
+          treeIndex: 999n, // out of bounds
+          value: [
+            VAULT_ADDRESS,
+            '1000000000000000000',
+            '50000000000000000',
+            '500000000000000000',
+            '600000000000000000',
+            '100000000000000000',
+          ],
+        },
+      ],
+    };
+
+    expect(() =>
+      getVaultData(reportWithBadIndex, VAULT_ADDRESS, TEST_CID),
+    ).toThrow('Leaf not found');
+  });
+
+  test('extracts data for second vault correctly', () => {
+    const result = getVaultData(MOCK_REPORT, VAULT_ADDRESS_2, TEST_CID);
+
+    expect(result.data.vaultAddress).toBe(VAULT_ADDRESS_2);
+    expect(result.data.totalValueWei).toBe('2000000000000000000');
+    expect(result.leaf).toBe(EXPECTED_LEAF_2);
+  });
+});
+
+describe('getReportProofByVault', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchIPFS).mockResolvedValue(MOCK_REPORT);
+  });
+
+  test('fetches IPFS data and returns proof', async () => {
+    const result = await getReportProofByVault({
+      vault: VAULT_ADDRESS,
+      cid: TEST_CID,
+    });
+
+    expect(fetchIPFS).toHaveBeenCalledWith({
+      cid: TEST_CID,
+      vault: VAULT_ADDRESS,
+    });
+    expect(result).toBeDefined();
+    expect(result.data.vaultAddress).toBe(VAULT_ADDRESS);
+    expect(Array.isArray(result.proof)).toBe(true);
+    expect(result.proof.length).toBeGreaterThan(0);
+    // Each proof element should be a hex string
+    for (const elem of result.proof) {
+      expect(elem).toMatch(/^0x[0-9a-f]+$/i);
+    }
+  });
+
+  test('proof verifies against the Merkle root', async () => {
+    const result = await getReportProofByVault({
+      vault: VAULT_ADDRESS,
+      cid: TEST_CID,
+    });
+
+    // Re-load the tree and verify the proof is correct
+    const tree = StandardMerkleTree.load({
+      ...MOCK_REPORT,
+      values: MOCK_REPORT.values.map(({ treeIndex, value }) => ({
+        treeIndex: Number(treeIndex),
+        value,
+      })),
+    });
+    expect(() => tree.verify(0, result.proof)).not.toThrow();
+  });
+
+  test('throws when vault not found in fetched report', async () => {
+    const unknownVault =
+      '0x9999999999999999999999999999999999999999' as Address;
+
+    await expect(
+      getReportProofByVault({ vault: unknownVault, cid: TEST_CID }),
+    ).rejects.toThrow(`Vault ${unknownVault} not found in report`);
+  });
+});
+
+describe('getReportProofs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(fetchIPFS).mockResolvedValue(MOCK_REPORT);
+  });
+
+  test('returns proofs for all vaults in report', async () => {
+    const results = await getReportProofs({ cid: TEST_CID });
+
+    expect(results).toHaveLength(2);
+    const addresses = results.map((r) => r.data.vaultAddress);
+    expect(addresses).toContain(VAULT_ADDRESS);
+    expect(addresses).toContain(VAULT_ADDRESS_2);
+  });
+
+  test('each proof contains required data fields', async () => {
+    const results = await getReportProofs({ cid: TEST_CID });
+
+    for (const result of results) {
+      expect(result.proof).toBeDefined();
+      expect(Array.isArray(result.proof)).toBe(true);
+      expect(result.proof.length).toBeGreaterThan(0);
+      expect(result.data.vaultAddress).toBeDefined();
+      expect(result.data.totalValueWei).toBeDefined();
+      expect(result.data.liabilityShares).toBeDefined();
+      expect(result.cid).toBe(TEST_CID);
+    }
+  });
+});

--- a/packages/sdk/src/stvault/__tests__/report-proof.test.ts
+++ b/packages/sdk/src/stvault/__tests__/report-proof.test.ts
@@ -60,12 +60,17 @@ const treeDump = realTree.dump();
 // Derive expected leaf hashes from the real tree for assertions
 const vault1Entry = treeDump.values.find(
   (v) => v.value[0]?.toLowerCase() === VAULT_ADDRESS.toLowerCase(),
-)!;
+);
+if (!vault1Entry) throw new Error('vault1Entry not found in tree');
 const vault2Entry = treeDump.values.find(
   (v) => v.value[0]?.toLowerCase() === VAULT_ADDRESS_2.toLowerCase(),
-)!;
-const EXPECTED_LEAF_1 = treeDump.tree[vault1Entry.treeIndex]!;
-const EXPECTED_LEAF_2 = treeDump.tree[vault2Entry.treeIndex]!;
+);
+if (!vault2Entry) throw new Error('vault2Entry not found in tree');
+
+const EXPECTED_LEAF_1 = treeDump.tree[vault1Entry.treeIndex];
+if (!EXPECTED_LEAF_1) throw new Error('EXPECTED_LEAF_1 not found in tree');
+const EXPECTED_LEAF_2 = treeDump.tree[vault2Entry.treeIndex];
+if (!EXPECTED_LEAF_2) throw new Error('EXPECTED_LEAF_2 not found in tree');
 
 const MOCK_REPORT: Report = {
   format: 'standard-v1',

--- a/packages/sdk/src/stvault/__tests__/vault-constants.test.ts
+++ b/packages/sdk/src/stvault/__tests__/vault-constants.test.ts
@@ -1,0 +1,56 @@
+import { describe, test, expect } from 'vitest';
+import {
+  MIN_NODE_OPERATOR_BP,
+  MAX_NODE_OPERATOR_BP,
+  SCAN_LIMIT,
+  BASIS_POINTS_DENOMINATOR,
+} from '../consts/common.js';
+import { dashboardRoles } from '../consts/roles.js';
+
+describe('stvault constants', () => {
+  test('MIN_NODE_OPERATOR_BP is 0', () => {
+    expect(MIN_NODE_OPERATOR_BP).toBe(0n);
+  });
+
+  test('MAX_NODE_OPERATOR_BP is 10000 (100%)', () => {
+    expect(MAX_NODE_OPERATOR_BP).toBe(10_000n);
+  });
+
+  test('SCAN_LIMIT is positive', () => {
+    expect(SCAN_LIMIT).toBeGreaterThan(0n);
+    expect(SCAN_LIMIT).toBe(100n);
+  });
+
+  test('BASIS_POINTS_DENOMINATOR is 10000', () => {
+    expect(BASIS_POINTS_DENOMINATOR).toBe(10_000n);
+  });
+
+  test('MIN < MAX for node operator fee', () => {
+    expect(MIN_NODE_OPERATOR_BP).toBeLessThan(MAX_NODE_OPERATOR_BP);
+  });
+});
+
+describe('dashboardRoles', () => {
+  test('is a non-empty array', () => {
+    expect(dashboardRoles).toBeDefined();
+    expect(dashboardRoles.length).toBeGreaterThan(0);
+  });
+
+  test('contains expected core roles', () => {
+    expect(dashboardRoles).toContain('DEFAULT_ADMIN_ROLE');
+    expect(dashboardRoles).toContain('FUND_ROLE');
+    expect(dashboardRoles).toContain('MINT_ROLE');
+    expect(dashboardRoles).toContain('BURN_ROLE');
+    expect(dashboardRoles).toContain('WITHDRAW_ROLE');
+  });
+
+  test('contains node operator roles', () => {
+    expect(dashboardRoles).toContain('NODE_OPERATOR_MANAGER_ROLE');
+    expect(dashboardRoles).toContain('NODE_OPERATOR_FEE_EXEMPT_ROLE');
+  });
+
+  test('all roles are unique strings', () => {
+    const unique = new Set(dashboardRoles);
+    expect(unique.size).toBe(dashboardRoles.length);
+  });
+});

--- a/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
+++ b/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
@@ -10,31 +10,28 @@ import type { Bus } from '../bus.js';
 const MOCK_BUS = {} as Bus;
 const VAULT_ADDRESS = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address;
 
-function makeEntity() {
-  return new LidoSDKVaultEntity({
+const makeEntity = () =>
+  new LidoSDKVaultEntity({
     bus: MOCK_BUS,
     vaultAddress: VAULT_ADDRESS,
   });
-}
 
 // ─── Base args factory ───────────────────────────────────────────────────────
-function makeArgs(overrides: Partial<OverviewArgs> = {}): OverviewArgs {
-  return {
-    totalValue: 10_000n * 10n ** 18n, // 10,000 ETH
-    reserveRatioBP: 1000, // 10%
-    liabilitySharesInStethWei: 1_000n * 10n ** 18n, // 1,000 stETH
-    forceRebalanceThresholdBP: 500, // 5%
-    withdrawableEther: 500n * 10n ** 18n,
-    balance: 200n * 10n ** 18n,
-    locked: 100n * 10n ** 18n,
-    nodeOperatorDisbursableFee: 10n * 10n ** 18n,
-    totalMintingCapacityStethWei: 5_000n * 10n ** 18n,
-    unsettledLidoFees: 5n * 10n ** 18n,
-    minimalReserve: 50n * 10n ** 18n,
-    reportLiabilitySharesStETH: 1_000n * 10n ** 18n,
-    ...overrides,
-  };
-}
+const makeArgs = (overrides: Partial<OverviewArgs> = {}): OverviewArgs => ({
+  totalValue: 10_000n * 10n ** 18n, // 10,000 ETH
+  reserveRatioBP: 1000, // 10%
+  liabilitySharesInStethWei: 1_000n * 10n ** 18n, // 1,000 stETH
+  forceRebalanceThresholdBP: 500, // 5%
+  withdrawableEther: 500n * 10n ** 18n,
+  balance: 200n * 10n ** 18n,
+  locked: 100n * 10n ** 18n,
+  nodeOperatorDisbursableFee: 10n * 10n ** 18n,
+  totalMintingCapacityStethWei: 5_000n * 10n ** 18n,
+  unsettledLidoFees: 5n * 10n ** 18n,
+  minimalReserve: 50n * 10n ** 18n,
+  reportLiabilitySharesStETH: 1_000n * 10n ** 18n,
+  ...overrides,
+});
 
 describe('LidoSDKVaultEntity.calculateHealth', () => {
   test('returns healthy for vault well above threshold', () => {

--- a/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
+++ b/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
@@ -1,0 +1,195 @@
+import { describe, test, expect } from 'vitest';
+import type { Address } from 'viem';
+import { LidoSDKVaultEntity } from '../vault-entity.js';
+import type { OverviewArgs } from '../utils/overview/types.js';
+import type { Bus } from '../bus.js';
+
+// ─── Minimal mock bus ────────────────────────────────────────────────────────
+// calculateOverview and calculateHealth are pure synchronous methods that do
+// not access this.bus at all, so a minimal cast is sufficient.
+const MOCK_BUS = {} as Bus;
+const VAULT_ADDRESS = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address;
+
+function makeEntity() {
+  return new LidoSDKVaultEntity({
+    bus: MOCK_BUS,
+    vaultAddress: VAULT_ADDRESS,
+  });
+}
+
+// ─── Base args factory ───────────────────────────────────────────────────────
+function makeArgs(overrides: Partial<OverviewArgs> = {}): OverviewArgs {
+  return {
+    totalValue: 10_000n * 10n ** 18n, // 10,000 ETH
+    reserveRatioBP: 1000, // 10%
+    liabilitySharesInStethWei: 1_000n * 10n ** 18n, // 1,000 stETH
+    forceRebalanceThresholdBP: 500, // 5%
+    withdrawableEther: 500n * 10n ** 18n,
+    balance: 200n * 10n ** 18n,
+    locked: 100n * 10n ** 18n,
+    nodeOperatorDisbursableFee: 10n * 10n ** 18n,
+    totalMintingCapacityStethWei: 5_000n * 10n ** 18n,
+    unsettledLidoFees: 5n * 10n ** 18n,
+    minimalReserve: 50n * 10n ** 18n,
+    reportLiabilitySharesStETH: 1_000n * 10n ** 18n,
+    ...overrides,
+  };
+}
+
+describe('LidoSDKVaultEntity.calculateHealth', () => {
+  test('returns healthy for vault well above threshold', () => {
+    const entity = makeEntity();
+    const result = entity.calculateHealth({
+      totalValue: 10_000n * 10n ** 18n,
+      liabilitySharesInStethWei: 1_000n * 10n ** 18n,
+      forceRebalanceThresholdBP: 500,
+    });
+
+    expect(result.isHealthy).toBe(true);
+    expect(result.healthRatio).toBeGreaterThan(100);
+  });
+
+  test('returns unhealthy when liability exceeds adjusted value', () => {
+    const entity = makeEntity();
+    const result = entity.calculateHealth({
+      totalValue: 1_000n * 10n ** 18n,
+      liabilitySharesInStethWei: 1_000n * 10n ** 18n,
+      forceRebalanceThresholdBP: 500, // 5% threshold reduces value to 950
+    });
+
+    // adjustedValue = 1000 * 0.95 = 950, liability = 1000 → 95% < 100%
+    expect(result.isHealthy).toBe(false);
+    expect(result.healthRatio).toBeLessThan(100);
+  });
+
+  test('returns Infinity health ratio when no liability', () => {
+    const entity = makeEntity();
+    const result = entity.calculateHealth({
+      totalValue: 1_000n * 10n ** 18n,
+      liabilitySharesInStethWei: 0n,
+      forceRebalanceThresholdBP: 500,
+    });
+
+    expect(result.isHealthy).toBe(true);
+    expect(result.healthRatio).toBe(Infinity);
+  });
+});
+
+describe('LidoSDKVaultEntity.calculateOverview', () => {
+  test('returns expected structure', () => {
+    const entity = makeEntity();
+    const result = entity.calculateOverview(makeArgs());
+
+    expect(result).toHaveProperty('healthRatio');
+    expect(result).toHaveProperty('isHealthy');
+    expect(result).toHaveProperty('availableToWithdrawal');
+    expect(result).toHaveProperty('idleCapital');
+    expect(result).toHaveProperty('totalLocked');
+    expect(result).toHaveProperty('collateral');
+    expect(result).toHaveProperty('recentlyRepaid');
+    expect(result).toHaveProperty('utilizationRatio');
+    expect(result).toHaveProperty('reserved');
+    expect(result).toHaveProperty('totalMintingCapacityStethWei');
+  });
+
+  test('availableToWithdrawal equals withdrawableEther', () => {
+    const entity = makeEntity();
+    const args = makeArgs({ withdrawableEther: 333n * 10n ** 18n });
+    const result = entity.calculateOverview(args);
+    expect(result.availableToWithdrawal).toBe(333n * 10n ** 18n);
+  });
+
+  test('idleCapital equals balance', () => {
+    const entity = makeEntity();
+    const args = makeArgs({ balance: 77n * 10n ** 18n });
+    const result = entity.calculateOverview(args);
+    expect(result.idleCapital).toBe(77n * 10n ** 18n);
+  });
+
+  test('totalLocked sums locked + nodeOperatorDisbursableFee + unsettledLidoFees', () => {
+    const entity = makeEntity();
+    const args = makeArgs({
+      locked: 100n,
+      nodeOperatorDisbursableFee: 20n,
+      unsettledLidoFees: 5n,
+    });
+    const result = entity.calculateOverview(args);
+    expect(result.totalLocked).toBe(125n);
+  });
+
+  test('utilizationRatio is zero when totalMintingCapacityStethWei is zero', () => {
+    const entity = makeEntity();
+    const args = makeArgs({ totalMintingCapacityStethWei: 0n });
+    const result = entity.calculateOverview(args);
+    expect(result.utilizationRatio).toBe(0);
+  });
+
+  test('utilizationRatio reflects actual utilization', () => {
+    const entity = makeEntity();
+    const args = makeArgs({
+      liabilitySharesInStethWei: 2_500n * 10n ** 18n,
+      totalMintingCapacityStethWei: 5_000n * 10n ** 18n,
+    });
+    const result = entity.calculateOverview(args);
+    // 2500 / 5000 = 50%
+    expect(result.utilizationRatio).toBeCloseTo(50, 0);
+  });
+
+  test('recentlyRepaid is zero when no repayment happened', () => {
+    const entity = makeEntity();
+    const args = makeArgs({
+      reportLiabilitySharesStETH: 1_000n * 10n ** 18n,
+      liabilitySharesInStethWei: 1_000n * 10n ** 18n, // same → no repayment
+    });
+    const result = entity.calculateOverview(args);
+    expect(result.recentlyRepaid).toBe(0n);
+  });
+
+  test('recentlyRepaid reflects repaid amount', () => {
+    const entity = makeEntity();
+    const args = makeArgs({
+      reportLiabilitySharesStETH: 2_000n * 10n ** 18n,
+      liabilitySharesInStethWei: 1_500n * 10n ** 18n, // 500 repaid
+    });
+    const result = entity.calculateOverview(args);
+    expect(result.recentlyRepaid).toBe(500n * 10n ** 18n);
+  });
+
+  test('isHealthy is true for vault with low liability', () => {
+    const entity = makeEntity();
+    const result = entity.calculateOverview(
+      makeArgs({
+        totalValue: 10_000n * 10n ** 18n,
+        liabilitySharesInStethWei: 100n * 10n ** 18n,
+        forceRebalanceThresholdBP: 500,
+      }),
+    );
+    expect(result.isHealthy).toBe(true);
+  });
+
+  test('isHealthy is false when liability exceeds threshold-adjusted totalValue', () => {
+    const entity = makeEntity();
+    const result = entity.calculateOverview(
+      makeArgs({
+        totalValue: 1_000n * 10n ** 18n,
+        liabilitySharesInStethWei: 1_000n * 10n ** 18n,
+        forceRebalanceThresholdBP: 500,
+      }),
+    );
+    expect(result.isHealthy).toBe(false);
+  });
+
+  test('collateral uses minimalReserve when it is larger', () => {
+    const entity = makeEntity();
+    // With very tiny liability, formula would give small collateral
+    // but minimalReserve is large
+    const largeMinimalReserve = 99_999n * 10n ** 18n;
+    const args = makeArgs({
+      liabilitySharesInStethWei: 1n,
+      minimalReserve: largeMinimalReserve,
+      reserveRatioBP: 1000, // 10%
+    });
+    const result = entity.calculateOverview(args);
+    expect(result.collateral).toBe(largeMinimalReserve);
+  });
+});

--- a/packages/sdk/src/unsteth/__tests__/unsteth-wallet.test.ts
+++ b/packages/sdk/src/unsteth/__tests__/unsteth-wallet.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, jest } from '@jest/globals';
+import { beforeAll, describe, expect, vi } from 'vitest';
 import { useUnsteth } from '../../../tests/utils/fixtures/use-unsteth.js';
 import { expectAddress } from '../../../tests/utils/expect/expect-address.js';
 import { expectPositiveBn } from '../../../tests/utils/expect/expect-bn.js';
@@ -35,7 +35,7 @@ describe('unsteth wallet tests', () => {
   let nftIds: bigint[] = [];
   let nftId = 0n;
 
-  jest.setTimeout(SPENDING_TIMEOUT);
+  vi.setConfig({ testTimeout: SPENDING_TIMEOUT });
 
   beforeAll(async () => {
     await unsteth.setAllTokensApproval({
@@ -121,7 +121,7 @@ describe('unsteth wallet tests', () => {
   });
 
   testSpending('can transfer token', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await unsteth.transfer({
       id: nftId,
       to: altAccount.address,
@@ -168,7 +168,7 @@ describe('unsteth wallet tests', () => {
   });
 
   testSpending('can approve single token', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await unsteth.setSingleTokenApproval({
       id: nftId,
       to: altAccount.address,
@@ -195,7 +195,7 @@ describe('unsteth wallet tests', () => {
   });
 
   testSpending('can revoke approve single token', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await unsteth.setSingleTokenApproval({
       id: nftId,
       callback: mock,
@@ -254,7 +254,7 @@ describe('unsteth wallet tests', () => {
   });
 
   testSpending('can approve for all tokens', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await unsteth.setAllTokensApproval({
       to: altAccount.address,
       allow: true,
@@ -282,7 +282,7 @@ describe('unsteth wallet tests', () => {
   });
 
   testSpending('can revoke approve for all tokens', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await unsteth.setAllTokensApproval({
       to: altAccount.address,
       allow: false,

--- a/packages/sdk/src/unsteth/__tests__/unsteth.test.ts
+++ b/packages/sdk/src/unsteth/__tests__/unsteth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from '@jest/globals';
+import { describe, expect, test } from 'vitest';
 import { expectSDKModule } from '../../../tests/utils/expect/expect-sdk-module.js';
 import { LidoSDKUnstETH } from '../unsteth.js';
 import { useUnsteth } from '../../../tests/utils/fixtures/use-unsteth.js';

--- a/packages/sdk/src/withdraw/__test__/withdraw-claim.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-claim.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { expect, describe, jest } from '@jest/globals';
+import { expect, describe, vi } from 'vitest';
 import { useUnsteth } from '../../../tests/utils/fixtures/use-unsteth.js';
 import { useAccount } from '../../../tests/utils/fixtures/use-wallet-client.js';
 import { useWithdraw } from '../../../tests/utils/fixtures/use-withdraw.js';
@@ -27,7 +27,7 @@ describe('withdraw request claim', () => {
   let request: RequestStatusWithId = {} as any;
   let claimableETH = 0n;
 
-  jest.setTimeout(SPENDING_TIMEOUT);
+  vi.setConfig({ testTimeout: SPENDING_TIMEOUT });
 
   testSpending('has at least 1 claimable requests', async () => {
     const claimable = await requestsInfo.getClaimableRequestsETHByAccount({
@@ -74,7 +74,7 @@ describe('withdraw request claim', () => {
     const balanceBefore = await core.balanceETH(address);
     const owner = await unsteth.getAccountByNFT(request.id);
     expectAddress(owner, address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await claim.claimRequests({
       requestsIds: [request.id],
       callback: mock,

--- a/packages/sdk/src/withdraw/__test__/withdraw-request-info.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-request-info.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 import { useWithdraw } from '../../../tests/utils/fixtures/use-withdraw.js';
 import { useUnsteth } from '../../../tests/utils/fixtures/use-unsteth.js';
 import { useAccount } from '../../../tests/utils/fixtures/use-wallet-client.js';

--- a/packages/sdk/src/withdraw/__test__/withdraw-request.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-request.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, jest, beforeAll, test } from '@jest/globals';
+import { expect, describe, vi, beforeAll, test } from 'vitest';
 import { useWithdraw } from '../../../tests/utils/fixtures/use-withdraw.js';
 import {
   expectAlmostEqualBn,
@@ -48,7 +48,7 @@ const testWithdrawalsWithPermit = (
   let wqAddress: Address;
   let permit: PermitSignature;
 
-  jest.setTimeout(SPENDING_TIMEOUT);
+  vi.setConfig({ testTimeout: SPENDING_TIMEOUT });
 
   beforeAll(async () => {
     const balanceBefore = await tokenContract.balance(address);
@@ -112,7 +112,7 @@ const testWithdrawalsWithPermit = (
   testSpending('can request withdrawals with permit', async () => {
     const balanceBefore = await tokenContract.balance(address);
     const nftsBefore = await unsteth.getNFTsByAccount(address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await request.requestWithdrawalWithPermit({
       permit,
       token,
@@ -149,7 +149,7 @@ const testWithdrawals = (token: WithdrawableTokens, ethAmount: bigint) => {
   let requestsAmounts: bigint[] = [];
   let wqAddress: Address;
 
-  jest.setTimeout(SPENDING_TIMEOUT);
+  vi.setConfig({ testTimeout: SPENDING_TIMEOUT });
 
   beforeAll(async () => {
     wqAddress = await contract.contractAddressWithdrawalQueue();
@@ -223,12 +223,12 @@ const testWithdrawals = (token: WithdrawableTokens, ethAmount: bigint) => {
     expectAddress(tx.request.address, tokenAddress);
   });
 
-  testSpending.failing('cannot withdraw without approve', async () => {
+  testSpending.fails('cannot withdraw without approve', async () => {
     await request.requestWithdrawal({ token, amount });
   });
 
   testSpending('can approve', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await approval.approve({
       token,
       amount,
@@ -288,7 +288,7 @@ const testWithdrawals = (token: WithdrawableTokens, ethAmount: bigint) => {
   testSpending('can request withdrawals', async () => {
     const balanceBefore = await tokenContract.balance(address);
     const nftsBefore = await unsteth.getNFTsByAccount(address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await request.requestWithdrawal({
       token,
       amount,

--- a/packages/sdk/src/withdraw/__test__/withdraw-views.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-views.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 import { useWithdraw } from '../../../tests/utils/fixtures/use-withdraw.js';
 import {
   expectAlmostEqualBn,

--- a/packages/sdk/src/withdraw/__test__/withdraw-waiting-time.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw-waiting-time.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 import { useWithdraw } from '../../../tests/utils/fixtures/use-withdraw.js';
 import { WithdrawalWaitingTimeByRequestIdsParams } from '../types.js';
 

--- a/packages/sdk/src/withdraw/__test__/withdraw.test.ts
+++ b/packages/sdk/src/withdraw/__test__/withdraw.test.ts
@@ -1,4 +1,4 @@
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 import {
   LIDO_CONTRACT_NAMES,
   LidoSDKCore,

--- a/packages/sdk/src/wrap/__test__/wrap-wallet.test.ts
+++ b/packages/sdk/src/wrap/__test__/wrap-wallet.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, jest } from '@jest/globals';
+import { describe, expect, vi } from 'vitest';
 import {
   SPENDING_TIMEOUT,
   testSpending,
@@ -32,7 +32,7 @@ describe('LidoSDKWrap wallet methods', () => {
   const wsteth = new LidoSDKwstETH({ core: wrap.core });
   let wstethValue = 0n;
 
-  jest.setTimeout(SPENDING_TIMEOUT);
+  vi.setConfig({ testTimeout: SPENDING_TIMEOUT });
 
   testSpending('stake', async () => {
     // we have to account for
@@ -40,18 +40,18 @@ describe('LidoSDKWrap wallet methods', () => {
   });
 
   testSpending('reset allowance', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await wrap.approveStethForWrap({ value: 0n, callback: mock });
     expectTxCallback(mock, tx);
     await expect(wrap.getStethForWrapAllowance(address)).resolves.toEqual(0n);
   });
 
-  testSpending.failing('simulate  failing', async () => {
+  testSpending.fails('simulate  failing', async () => {
     await wrap.wrapStethSimulateTx({ value });
   });
 
   testSpending('set allowance', async () => {
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await wrap.approveStethForWrap({ value, callback: mock });
     expectTxCallback(mock, tx);
     await expect(wrap.getStethForWrapAllowance(address)).resolves.toEqual(
@@ -87,7 +87,7 @@ describe('LidoSDKWrap wallet methods', () => {
     wstethValue = await wrap.convertStethToWsteth(value);
     const stethBalanceBefore = await steth.balance(address);
     const wstethBalanceBefore = await wsteth.balance(address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await wrap.wrapSteth({ value, callback: mock });
     expectTxCallback(mock, tx);
     const stethBalanceAfter = await steth.balance(address);
@@ -135,7 +135,7 @@ describe('LidoSDKWrap wallet methods', () => {
   testSpending('unwrap steth', async () => {
     const stethBalanceBefore = await steth.balance(address);
     const wstethBalanceBefore = await wsteth.balance(address);
-    const mock = jest.fn<TransactionCallback>();
+    const mock = vi.fn<TransactionCallback>();
     const tx = await wrap.unwrap({ value: wstethValue, callback: mock });
     expectTxCallback(mock, tx);
     const stethBalanceAfter = await steth.balance(address);

--- a/packages/sdk/src/wrap/__test__/wrap.test.ts
+++ b/packages/sdk/src/wrap/__test__/wrap.test.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData } from 'viem';
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 
 import { LidoSDKWrap } from '../wrap.js';
 import { WstethReferralStakerABI } from '../abi/wsteth-referral-staker.js';

--- a/packages/sdk/tests/global-setup.ts
+++ b/packages/sdk/tests/global-setup.ts
@@ -23,7 +23,7 @@ dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
  * Requires the `anvil` binary from Foundry:
  *   https://book.getfoundry.sh/getting-started/installation
  */
-export async function setup() {
+export const setup = async () => {
   if (!process.env.TEST_RPC_URL || !process.env.TEST_CHAIN_ID) {
     // No network env configured — unit tests only, nothing to start.
     return;
@@ -43,10 +43,9 @@ export async function setup() {
     return anvil;
   };
 
-  const instances = [];
+  const instances: Array<Awaited<ReturnType<typeof startAnvil>>> = [];
 
   const anvil = await startAnvil(process.env.TEST_RPC_URL);
-  // Written to process.env so forked workers inherit it automatically.
   process.env.VITEST_ANVIL_PORT = String(anvil.port);
   instances.push(anvil);
 
@@ -56,7 +55,6 @@ export async function setup() {
     instances.push(l2Anvil);
   }
 
-  // Returned function is called by vitest after all tests finish.
   return async () => {
     await Promise.allSettled(instances.map((a) => a.stop()));
   };

--- a/packages/sdk/tests/global-setup.ts
+++ b/packages/sdk/tests/global-setup.ts
@@ -1,0 +1,63 @@
+import net from 'node:net';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+
+const getFreePort = (): Promise<number> =>
+  new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.listen(0, () => {
+      const port = (srv.address() as net.AddressInfo).port;
+      srv.close(() => resolve(port));
+    });
+  });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+/**
+ * Vitest globalSetup — runs in the main process before any test worker starts.
+ * Anvil processes are started here and their ports written to process.env so that
+ * forked test workers (which inherit the env) can connect via HTTP.
+ *
+ * Requires the `anvil` binary from Foundry:
+ *   https://book.getfoundry.sh/getting-started/installation
+ */
+export async function setup() {
+  if (!process.env.TEST_RPC_URL || !process.env.TEST_CHAIN_ID) {
+    // No network env configured — unit tests only, nothing to start.
+    return;
+  }
+
+  const { createAnvil } = await import('@viem/anvil');
+
+  const startAnvil = async (forkUrl: string) => {
+    // forkChainId is intentionally omitted: Anvil inherits the chain ID from
+    // the fork automatically, and passing it together with --fork-url requires
+    // --fork-block-number which we don't want to pin.
+    //
+    // Port is chosen dynamically so parallel/repeated runs don't collide.
+    const port = await getFreePort();
+    const anvil = createAnvil({ forkUrl, port });
+    await anvil.start();
+    return anvil;
+  };
+
+  const instances = [];
+
+  const anvil = await startAnvil(process.env.TEST_RPC_URL);
+  // Written to process.env so forked workers inherit it automatically.
+  process.env.VITEST_ANVIL_PORT = String(anvil.port);
+  instances.push(anvil);
+
+  if (process.env.TEST_L2_RPC_URL) {
+    const l2Anvil = await startAnvil(process.env.TEST_L2_RPC_URL);
+    process.env.VITEST_L2_ANVIL_PORT = String(l2Anvil.port);
+    instances.push(l2Anvil);
+  }
+
+  // Returned function is called by vitest after all tests finish.
+  return async () => {
+    await Promise.allSettled(instances.map((a) => a.stop()));
+  };
+}

--- a/packages/sdk/tests/mocks/multiformats.mock.ts
+++ b/packages/sdk/tests/mocks/multiformats.mock.ts
@@ -38,15 +38,14 @@ vi.mock('blockstore-core', () => {
   return { MemoryBlockstore: MockBlockstore };
 });
 
-vi.mock('ipfs-unixfs-importer', () => {
-  const importer = async function* (entries: any[]) {
-    for (const entry of entries) {
-      yield {
-        cid: { toString: () => `mocked-cid-${entry.path ?? ''}` },
-        path: entry.path,
-        size: entry.content?.length ?? 0,
-      };
-    }
-  };
-  return { importer };
-});
+const importer = async function* (entries: any[]) {
+  for (const entry of entries) {
+    yield {
+      cid: { toString: () => `mocked-cid-${entry.path ?? ''}` },
+      path: entry.path,
+      size: entry.content?.length ?? 0,
+    };
+  }
+};
+
+vi.mock('ipfs-unixfs-importer', () => ({ importer }));

--- a/packages/sdk/tests/mocks/multiformats.mock.ts
+++ b/packages/sdk/tests/mocks/multiformats.mock.ts
@@ -1,0 +1,52 @@
+import { vi } from 'vitest';
+
+vi.mock('multiformats/cid', () => {
+  class MockCID {
+    str: string;
+    constructor(str: string) {
+      this.str = str;
+    }
+    toString() {
+      return this.str;
+    }
+    equals(other: any) {
+      return other != null && other.str === this.str;
+    }
+    static parse(str: string) {
+      return new MockCID(str);
+    }
+  }
+  return { CID: MockCID };
+});
+
+vi.mock('blockstore-core', () => {
+  class MockBlockstore {
+    store = new Map<string, any>();
+    async put(key: any, value: any) {
+      this.store.set(key.toString(), value);
+    }
+    async get(key: any) {
+      return this.store.get(key.toString());
+    }
+    async has(key: any) {
+      return this.store.has(key.toString());
+    }
+    async delete(key: any) {
+      this.store.delete(key.toString());
+    }
+  }
+  return { MemoryBlockstore: MockBlockstore };
+});
+
+vi.mock('ipfs-unixfs-importer', () => {
+  const importer = async function* (entries: any[]) {
+    for (const entry of entries) {
+      yield {
+        cid: { toString: () => `mocked-cid-${entry.path ?? ''}` },
+        path: entry.path,
+        size: entry.content?.length ?? 0,
+      };
+    }
+  };
+  return { importer };
+});

--- a/packages/sdk/tests/utils/expect/expect-address.ts
+++ b/packages/sdk/tests/utils/expect/expect-address.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 import { isAddress } from 'viem';
 
 export const expectAddress = (address: any, expected?: string) => {

--- a/packages/sdk/tests/utils/expect/expect-bn.ts
+++ b/packages/sdk/tests/utils/expect/expect-bn.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 
 export const expectBn = (value: any) => {
   expect(typeof value === 'bigint');

--- a/packages/sdk/tests/utils/expect/expect-contract.ts
+++ b/packages/sdk/tests/utils/expect/expect-contract.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 import { expectAddress } from './expect-address.js';
 
 export const expectContract = (contract: any, address?: string) => {

--- a/packages/sdk/tests/utils/expect/expect-erc20-wallet.ts
+++ b/packages/sdk/tests/utils/expect/expect-erc20-wallet.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData, getContract, maxUint256 } from 'viem';
-import { expect, describe, test, jest } from '@jest/globals';
+import { expect, describe, test, vi } from 'vitest';
 import { AbstractLidoSDKErc20 } from '../../../src/erc20/erc20.js';
 import {
   LIDO_CONTRACT_NAMES,
@@ -91,7 +91,7 @@ export const expectERC20Wallet = <I extends AbstractLidoSDKErc20>({
   };
 
   describe('wallet methods', () => {
-    jest.setTimeout(SPENDING_TIMEOUT);
+    vi.setConfig({ testTimeout: SPENDING_TIMEOUT });
 
     /**
      * Approve
@@ -102,7 +102,7 @@ export const expectERC20Wallet = <I extends AbstractLidoSDKErc20>({
         const params = {
           to: account,
           amount: 100n,
-          callback: jest.fn<TransactionCallback>(),
+          callback: vi.fn<TransactionCallback>(),
         };
 
         const tx = await token.approve(params);
@@ -183,7 +183,7 @@ export const expectERC20Wallet = <I extends AbstractLidoSDKErc20>({
           to: altAddress,
           from: address,
           amount: 100n,
-          callback: jest.fn<TransactionCallback>(),
+          callback: vi.fn<TransactionCallback>(),
         };
 
         const tx = await token.transfer(params);

--- a/packages/sdk/tests/utils/expect/expect-erc20.ts
+++ b/packages/sdk/tests/utils/expect/expect-erc20.ts
@@ -1,5 +1,5 @@
 import { getContract } from 'viem';
-import { expect, describe, test } from '@jest/globals';
+import { expect, describe, test } from 'vitest';
 import { AbstractLidoSDKErc20 } from '../../../src/erc20/erc20.js';
 import {
   LIDO_CONTRACT_NAMES,

--- a/packages/sdk/tests/utils/expect/expect-hash.ts
+++ b/packages/sdk/tests/utils/expect/expect-hash.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 
 export const expectHash = (hash: any) => {
   expect(typeof hash).toBe('string');

--- a/packages/sdk/tests/utils/expect/expect-populated-tx.ts
+++ b/packages/sdk/tests/utils/expect/expect-populated-tx.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 import { expectAddress } from './expect-address.js';
 import { expectHash } from './expect-hash.js';
 import { PublicClient } from 'viem';

--- a/packages/sdk/tests/utils/expect/expect-rebase-event.ts
+++ b/packages/sdk/tests/utils/expect/expect-rebase-event.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 import { expectPositiveBn } from './expect-bn.js';
 import { expectAddress } from './expect-address.js';
 

--- a/packages/sdk/tests/utils/expect/expect-rewards-snapshot.ts
+++ b/packages/sdk/tests/utils/expect/expect-rewards-snapshot.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 import {
   GetRewardsFromChainOptions,
   GetRewardsFromChainResult,

--- a/packages/sdk/tests/utils/expect/expect-sdk-error.ts
+++ b/packages/sdk/tests/utils/expect/expect-sdk-error.ts
@@ -1,5 +1,5 @@
 import { ERROR_CODE, SDKError } from '../../../src/index.js';
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 
 export const expectSDKError = async (
   callback: () => any | Promise<any>,

--- a/packages/sdk/tests/utils/expect/expect-sdk-module.ts
+++ b/packages/sdk/tests/utils/expect/expect-sdk-module.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 import { LidoSDKModule } from '../../../src/common/class-primitives/sdk-module.js';
 import { LidoSDKCommonProps } from '../../../src/core/types.js';
 import { LidoSDKCore } from '../../../src/index.js';

--- a/packages/sdk/tests/utils/expect/expect-tx-callback.ts
+++ b/packages/sdk/tests/utils/expect/expect-tx-callback.ts
@@ -1,4 +1,4 @@
-import { expect, jest } from '@jest/globals';
+import { expect, vi } from 'vitest';
 import {
   TransactionCallback,
   TransactionCallbackStage,
@@ -6,9 +6,9 @@ import {
 import { expectPositiveBn } from './expect-bn.js';
 import { expectHash } from './expect-hash.js';
 
-const mockTxCallback = jest.fn<TransactionCallback>();
+const mockTxCallback = vi.fn<TransactionCallback>();
 
-export const useMockCallback = () => jest.fn<TransactionCallback>();
+export const useMockCallback = () => vi.fn<TransactionCallback>();
 
 type ExpectTxCallbackOptions = {
   hasPermit?: boolean;

--- a/packages/sdk/tests/utils/expect/expect-unique-array.ts
+++ b/packages/sdk/tests/utils/expect/expect-unique-array.ts
@@ -1,4 +1,4 @@
-import { expect } from '@jest/globals';
+import { expect } from 'vitest';
 
 export const expectUniqueArray = (arr: any) => {
   expect(Array.isArray(arr)).toBe(true);

--- a/packages/sdk/tests/utils/fixtures/use-l2.ts
+++ b/packages/sdk/tests/utils/fixtures/use-l2.ts
@@ -1,12 +1,12 @@
-import type { EthereumProvider } from 'ganache';
 import {
+  http,
   createTestClient,
   createWalletClient,
   custom,
-  PrivateKeyAccount,
+  type PrivateKeyAccount,
+  type PublicClient,
+  type TestClient,
   publicActions,
-  PublicClient,
-  TestClient,
 } from 'viem';
 import { useTestsEnvs } from './use-test-envs.js';
 import { CHAINS, LidoSDKCore, VIEM_CHAINS } from '../../../src/index.js';
@@ -14,32 +14,22 @@ import { useAccount } from './use-wallet-client.js';
 import { LidoSDKL2 } from '../../../src/l2/l2.js';
 
 let cached: {
-  testClient: TestClient<'ganache'>;
-  ganacheProvider: EthereumProvider;
+  testClient: TestClient<'anvil'>;
 } | null = null;
 
 export const useTestL2RpcProvider = () => {
   if (cached) return cached;
   const { l2ChainId } = useTestsEnvs();
 
-  const ganacheProvider = (globalThis as any)
-    .__l2_ganache_provider__ as EthereumProvider;
-
+  const port = Number(process.env.VITEST_L2_ANVIL_PORT);
   const testClient = createTestClient({
-    mode: 'ganache',
-    transport: custom({
-      async request(args) {
-        if (args.method === 'eth_estimateGas') {
-          delete args.params[0].gas;
-        }
-        return ganacheProvider.request(args);
-      },
-    }),
+    mode: 'anvil',
+    transport: http(`http://127.0.0.1:${port}`),
     name: 'testClient',
     chain: VIEM_CHAINS[l2ChainId as CHAINS],
   });
 
-  cached = { ganacheProvider, testClient };
+  cached = { testClient };
   return cached;
 };
 

--- a/packages/sdk/tests/utils/fixtures/use-mock-transport.ts
+++ b/packages/sdk/tests/utils/fixtures/use-mock-transport.ts
@@ -1,5 +1,4 @@
 import { custom, http } from 'viem';
-import { useTestRpcProvider } from './use-test-rpc-provider.js';
 import { useTestsEnvs } from './use-test-envs.js';
 
 export type MockTransportCallback = (
@@ -22,9 +21,9 @@ export const useMockTransport = (
 ) => {
   const { useDirectRpc = false } = options;
   const { rpcUrl } = useTestsEnvs();
-  const originalRequest: (args: any) => Promise<any> = useDirectRpc
-    ? (args: any) => http(rpcUrl)({}).request(args)
-    : (args: any) => useTestRpcProvider().ganacheProvider.request(args);
+  const anvilUrl = `http://127.0.0.1:${process.env.VITEST_ANVIL_PORT}`;
+  const baseUrl = useDirectRpc ? rpcUrl : anvilUrl;
+  const originalRequest = (args: any) => http(baseUrl)({}).request(args);
   return custom({
     async request(args) {
       return callback(args, async (customArgs: any = args) =>

--- a/packages/sdk/tests/utils/fixtures/use-test-rpc-provider.ts
+++ b/packages/sdk/tests/utils/fixtures/use-test-rpc-provider.ts
@@ -1,40 +1,29 @@
-import type { EthereumProvider } from 'ganache';
 import {
+  http,
   createTestClient,
-  custom,
   publicActions,
-  PublicClient,
-  TestClient,
+  type PublicClient,
+  type TestClient,
 } from 'viem';
 import { useTestsEnvs } from './use-test-envs.js';
 import { CHAINS, VIEM_CHAINS } from '../../../src/index.js';
 
 let cached: {
-  testClient: TestClient<'ganache'>;
-  ganacheProvider: EthereumProvider;
+  testClient: TestClient<'anvil'>;
 } | null = null;
 
 export const useTestRpcProvider = () => {
   if (cached) return cached;
   const { chainId } = useTestsEnvs();
 
-  const ganacheProvider = (globalThis as any)
-    .__ganache_provider__ as EthereumProvider;
-
+  const port = Number(process.env.VITEST_ANVIL_PORT);
   const testClient = createTestClient({
-    mode: 'ganache',
-    transport: custom({
-      async request(args) {
-        if (args.method === 'eth_estimateGas') {
-          delete args.params[0].gas;
-        }
-        return ganacheProvider.request(args);
-      },
-    }),
+    mode: 'anvil',
+    transport: http(`http://127.0.0.1:${port}`),
     name: 'testClient',
     chain: VIEM_CHAINS[chainId as CHAINS],
   });
-  cached = { ganacheProvider, testClient };
+  cached = { testClient };
   return cached;
 };
 

--- a/packages/sdk/tests/utils/test-spending.ts
+++ b/packages/sdk/tests/utils/test-spending.ts
@@ -1,15 +1,9 @@
-import { test, xtest } from '@jest/globals';
+import { test } from 'vitest';
 import { useTestsEnvs } from './fixtures/use-test-envs.js';
 
 const { skipSpendingTests } = useTestsEnvs();
 
 export const SPENDING_TIMEOUT = 120_000;
-
-// Pollute test.skip with missing fields so that it can be stand in for test
-(test.skip as any).concurrent = xtest;
-(test.skip as any).only = xtest;
-(test.skip as any).skip = xtest;
-(test.skip as any).todo = xtest;
 
 type TestType = typeof test;
 export const testSpending: TestType = skipSpendingTests

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,11 +1,11 @@
 {
   // This configuration is used for local development and type checking.
   "extends": "../../tsconfig.base.json",
-  "outDir": "dist",
-  "baseUrl": "./src/",
-  "include": ["src", "tests", "jest.config.ts"],
+  "include": ["src", "tests", "vitest.config.ts"],
   "exclude": ["node_modules", "dist", "__test__"],
   "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": "./src/",
     "resolveJsonModule": true
   }
 }

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  esbuild: {
+    // accessor keyword requires ES2022+ (class accessor proposal)
+    target: 'es2022',
+  },
+  test: {
+    environment: 'node',
+    pool: 'forks',
+    poolOptions: {
+      forks: {
+        singleFork: true,
+      },
+    },
+    testTimeout: 120_000,
+    globalSetup: './tests/global-setup.ts',
+    setupFiles: ['./tests/mocks/multiformats.mock.ts'],
+    include: ['src/**/*.test.ts'],
+    exclude: ['src/**/*-snapshot.ts', 'node_modules/**'],
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -214,7 +214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.27.1":
+"@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.21.4, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
   dependencies:
@@ -232,7 +232,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.11.6, @babel/core@npm:^7.12.3, @babel/core@npm:^7.19.6, @babel/core@npm:^7.21.3, @babel/core@npm:^7.25.9":
+"@babel/core@npm:^7.19.6, @babel/core@npm:^7.21.3, @babel/core@npm:^7.25.9":
   version: 7.28.3
   resolution: "@babel/core@npm:7.28.3"
   dependencies:
@@ -255,7 +255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.25.9, @babel/generator@npm:^7.28.3, @babel/generator@npm:^7.7.2":
+"@babel/generator@npm:^7.25.9, @babel/generator@npm:^7.28.3":
   version: 7.28.3
   resolution: "@babel/generator@npm:7.28.3"
   dependencies:
@@ -384,7 +384,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.10.4, @babel/helper-plugin-utils@npm:^7.12.13, @babel/helper-plugin-utils@npm:^7.14.5, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.8.0":
+"@babel/helper-plugin-utils@npm:^7.0.0, @babel/helper-plugin-utils@npm:^7.18.6, @babel/helper-plugin-utils@npm:^7.27.1, @babel/helper-plugin-utils@npm:^7.8.0":
   version: 7.27.1
   resolution: "@babel/helper-plugin-utils@npm:7.27.1"
   checksum: 5d715055301badab62bdb2336075a77f8dc8bd290cad2bc1b37ea3bf1b3efc40594d308082229f239deb4d6b5b80b0a73bce000e595ea74416e0339c11037047
@@ -469,7 +469,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.3":
+"@babel/parser@npm:^7.27.2, @babel/parser@npm:^7.28.3":
   version: 7.28.3
   resolution: "@babel/parser@npm:7.28.3"
   dependencies:
@@ -548,39 +548,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-async-generators@npm:^7.8.4":
-  version: 7.8.4
-  resolution: "@babel/plugin-syntax-async-generators@npm:7.8.4"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 7ed1c1d9b9e5b64ef028ea5e755c0be2d4e5e4e3d6cf7df757b9a8c4cfa4193d268176d0f1f7fbecdda6fe722885c7fda681f480f3741d8a2d26854736f05367
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-bigint@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/plugin-syntax-bigint@npm:7.8.3"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 3a10849d83e47aec50f367a9e56a6b22d662ddce643334b087f9828f4c3dd73bdc5909aaeabe123fed78515767f9ca43498a0e621c438d1cd2802d7fae3c9648
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-class-properties@npm:^7.8.3":
-  version: 7.12.13
-  resolution: "@babel/plugin-syntax-class-properties@npm:7.12.13"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.12.13
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 24f34b196d6342f28d4bad303612d7ff566ab0a013ce89e775d98d6f832969462e7235f3e7eaf17678a533d4be0ba45d3ae34ab4e5a9dcbda5d98d49e5efa2fc
-  languageName: node
-  linkType: hard
-
 "@babel/plugin-syntax-dynamic-import@npm:^7.8.3":
   version: 7.8.3
   resolution: "@babel/plugin-syntax-dynamic-import@npm:7.8.3"
@@ -614,29 +581,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-import-meta@npm:^7.8.3":
-  version: 7.10.4
-  resolution: "@babel/plugin-syntax-import-meta@npm:7.10.4"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 166ac1125d10b9c0c430e4156249a13858c0366d38844883d75d27389621ebe651115cb2ceb6dc011534d5055719fa1727b59f39e1ab3ca97820eef3dcab5b9b
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-json-strings@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/plugin-syntax-json-strings@npm:7.8.3"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: bf5aea1f3188c9a507e16efe030efb996853ca3cadd6512c51db7233cc58f3ac89ff8c6bdfb01d30843b161cfe7d321e1bf28da82f7ab8d7e6bc5464666f354a
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-jsx@npm:^7.22.5, @babel/plugin-syntax-jsx@npm:^7.27.1, @babel/plugin-syntax-jsx@npm:^7.7.2":
+"@babel/plugin-syntax-jsx@npm:^7.22.5, @babel/plugin-syntax-jsx@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-syntax-jsx@npm:7.27.1"
   dependencies:
@@ -647,84 +592,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/plugin-syntax-logical-assignment-operators@npm:^7.8.3":
-  version: 7.10.4
-  resolution: "@babel/plugin-syntax-logical-assignment-operators@npm:7.10.4"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: aff33577037e34e515911255cdbb1fd39efee33658aa00b8a5fd3a4b903585112d037cce1cc9e4632f0487dc554486106b79ccd5ea63a2e00df4363f6d4ff886
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-nullish-coalescing-operator@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/plugin-syntax-nullish-coalescing-operator@npm:7.8.3"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 87aca4918916020d1fedba54c0e232de408df2644a425d153be368313fdde40d96088feed6c4e5ab72aac89be5d07fef2ddf329a15109c5eb65df006bf2580d1
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-numeric-separator@npm:^7.8.3":
-  version: 7.10.4
-  resolution: "@babel/plugin-syntax-numeric-separator@npm:7.10.4"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.10.4
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 01ec5547bd0497f76cc903ff4d6b02abc8c05f301c88d2622b6d834e33a5651aa7c7a3d80d8d57656a4588f7276eba357f6b7e006482f5b564b7a6488de493a1
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-object-rest-spread@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/plugin-syntax-object-rest-spread@npm:7.8.3"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: fddcf581a57f77e80eb6b981b10658421bc321ba5f0a5b754118c6a92a5448f12a0c336f77b8abf734841e102e5126d69110a306eadb03ca3e1547cab31f5cbf
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-optional-catch-binding@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/plugin-syntax-optional-catch-binding@npm:7.8.3"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: 910d90e72bc90ea1ce698e89c1027fed8845212d5ab588e35ef91f13b93143845f94e2539d831dc8d8ededc14ec02f04f7bd6a8179edd43a326c784e7ed7f0b9
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-optional-chaining@npm:^7.8.3":
-  version: 7.8.3
-  resolution: "@babel/plugin-syntax-optional-chaining@npm:7.8.3"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.8.0
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: eef94d53a1453361553c1f98b68d17782861a04a392840341bc91780838dd4e695209c783631cf0de14c635758beafb6a3a65399846ffa4386bff90639347f30
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-top-level-await@npm:^7.8.3":
-  version: 7.14.5
-  resolution: "@babel/plugin-syntax-top-level-await@npm:7.14.5"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.14.5
-  peerDependencies:
-    "@babel/core": ^7.0.0-0
-  checksum: bbd1a56b095be7820029b209677b194db9b1d26691fe999856462e66b25b281f031f3dfd91b1619e9dcf95bebe336211833b854d0fb8780d618e35667c2d0d7e
-  languageName: node
-  linkType: hard
-
-"@babel/plugin-syntax-typescript@npm:^7.27.1, @babel/plugin-syntax-typescript@npm:^7.7.2":
+"@babel/plugin-syntax-typescript@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/plugin-syntax-typescript@npm:7.27.1"
   dependencies:
@@ -1579,7 +1447,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.27.1, @babel/template@npm:^7.27.2, @babel/template@npm:^7.3.3":
+"@babel/template@npm:^7.27.1, @babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
   dependencies:
@@ -1605,20 +1473,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.21.3, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.3.3, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.20.0, @babel/types@npm:^7.21.3, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.4.4":
   version: 7.28.2
   resolution: "@babel/types@npm:7.28.2"
   dependencies:
     "@babel/helper-string-parser": ^7.27.1
     "@babel/helper-validator-identifier": ^7.27.1
   checksum: 2218f0996d5fbadc4e3428c4c38f4ed403f0e2634e3089beba2c89783268c0c1d796a23e65f9f1ff8547b9061ae1a67691c76dc27d0b457e5fa9f2dd4e022e49
-  languageName: node
-  linkType: hard
-
-"@bcoe/v8-coverage@npm:^0.2.3":
-  version: 0.2.3
-  resolution: "@bcoe/v8-coverage@npm:0.2.3"
-  checksum: 850f9305536d0f2bd13e9e0881cb5f02e4f93fad1189f7b2d4bebf694e3206924eadee1068130d43c11b750efcc9405f88a8e42ef098b6d75239c0f047de1a27
   languageName: node
   linkType: hard
 
@@ -3187,6 +3048,167 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@esbuild/aix-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/aix-ppc64@npm:0.21.5"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm64@npm:0.21.5"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-arm@npm:0.21.5"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/android-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/android-x64@npm:0.21.5"
+  conditions: os=android & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-arm64@npm:0.21.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/darwin-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/darwin-x64@npm:0.21.5"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-arm64@npm:0.21.5"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/freebsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/freebsd-x64@npm:0.21.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm64@npm:0.21.5"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-arm@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-arm@npm:0.21.5"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ia32@npm:0.21.5"
+  conditions: os=linux & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-loong64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-loong64@npm:0.21.5"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-mips64el@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-mips64el@npm:0.21.5"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-ppc64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-ppc64@npm:0.21.5"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-riscv64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-riscv64@npm:0.21.5"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-s390x@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-s390x@npm:0.21.5"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@esbuild/linux-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/linux-x64@npm:0.21.5"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/netbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/netbsd-x64@npm:0.21.5"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/openbsd-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/openbsd-x64@npm:0.21.5"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/sunos-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/sunos-x64@npm:0.21.5"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-arm64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-arm64@npm:0.21.5"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-ia32@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-ia32@npm:0.21.5"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@esbuild/win32-x64@npm:0.21.5":
+  version: 0.21.5
+  resolution: "@esbuild/win32-x64@npm:0.21.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@eslint-community/eslint-utils@npm:^4.1.2, @eslint-community/eslint-utils@npm:^4.2.0, @eslint-community/eslint-utils@npm:^4.4.0":
   version: 4.9.1
   resolution: "@eslint-community/eslint-utils@npm:4.9.1"
@@ -3913,239 +3935,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@istanbuljs/load-nyc-config@npm:^1.0.0":
-  version: 1.1.0
-  resolution: "@istanbuljs/load-nyc-config@npm:1.1.0"
-  dependencies:
-    camelcase: ^5.3.1
-    find-up: ^4.1.0
-    get-package-type: ^0.1.0
-    js-yaml: ^3.13.1
-    resolve-from: ^5.0.0
-  checksum: d578da5e2e804d5c93228450a1380e1a3c691de4953acc162f387b717258512a3e07b83510a936d9fab03eac90817473917e24f5d16297af3867f59328d58568
-  languageName: node
-  linkType: hard
-
-"@istanbuljs/schema@npm:^0.1.2":
-  version: 0.1.3
-  resolution: "@istanbuljs/schema@npm:0.1.3"
-  checksum: 5282759d961d61350f33d9118d16bcaed914ebf8061a52f4fa474b2cb08720c9c81d165e13b82f2e5a8a212cc5af482f0c6fc1ac27b9e067e5394c9a6ed186c9
-  languageName: node
-  linkType: hard
-
-"@jest/console@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/console@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    chalk: ^4.0.0
-    jest-message-util: ^29.7.0
-    jest-util: ^29.7.0
-    slash: ^3.0.0
-  checksum: 0e3624e32c5a8e7361e889db70b170876401b7d70f509a2538c31d5cd50deb0c1ae4b92dc63fe18a0902e0a48c590c21d53787a0df41a52b34fa7cab96c384d6
-  languageName: node
-  linkType: hard
-
-"@jest/core@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/core@npm:29.7.0"
-  dependencies:
-    "@jest/console": ^29.7.0
-    "@jest/reporters": ^29.7.0
-    "@jest/test-result": ^29.7.0
-    "@jest/transform": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    ansi-escapes: ^4.2.1
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    exit: ^0.1.2
-    graceful-fs: ^4.2.9
-    jest-changed-files: ^29.7.0
-    jest-config: ^29.7.0
-    jest-haste-map: ^29.7.0
-    jest-message-util: ^29.7.0
-    jest-regex-util: ^29.6.3
-    jest-resolve: ^29.7.0
-    jest-resolve-dependencies: ^29.7.0
-    jest-runner: ^29.7.0
-    jest-runtime: ^29.7.0
-    jest-snapshot: ^29.7.0
-    jest-util: ^29.7.0
-    jest-validate: ^29.7.0
-    jest-watcher: ^29.7.0
-    micromatch: ^4.0.4
-    pretty-format: ^29.7.0
-    slash: ^3.0.0
-    strip-ansi: ^6.0.0
-  peerDependencies:
-    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  checksum: af759c9781cfc914553320446ce4e47775ae42779e73621c438feb1e4231a5d4862f84b1d8565926f2d1aab29b3ec3dcfdc84db28608bdf5f29867124ebcfc0d
-  languageName: node
-  linkType: hard
-
-"@jest/environment@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/environment@npm:29.7.0"
-  dependencies:
-    "@jest/fake-timers": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    jest-mock: ^29.7.0
-  checksum: 6fb398143b2543d4b9b8d1c6dbce83fa5247f84f550330604be744e24c2bd2178bb893657d62d1b97cf2f24baf85c450223f8237cccb71192c36a38ea2272934
-  languageName: node
-  linkType: hard
-
-"@jest/expect-utils@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/expect-utils@npm:29.7.0"
-  dependencies:
-    jest-get-type: ^29.6.3
-  checksum: 75eb177f3d00b6331bcaa057e07c0ccb0733a1d0a1943e1d8db346779039cb7f103789f16e502f888a3096fb58c2300c38d1f3748b36a7fa762eb6f6d1b160ed
-  languageName: node
-  linkType: hard
-
-"@jest/expect@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/expect@npm:29.7.0"
-  dependencies:
-    expect: ^29.7.0
-    jest-snapshot: ^29.7.0
-  checksum: a01cb85fd9401bab3370618f4b9013b90c93536562222d920e702a0b575d239d74cecfe98010aaec7ad464f67cf534a353d92d181646a4b792acaa7e912ae55e
-  languageName: node
-  linkType: hard
-
-"@jest/fake-timers@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/fake-timers@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    "@sinonjs/fake-timers": ^10.0.2
-    "@types/node": "*"
-    jest-message-util: ^29.7.0
-    jest-mock: ^29.7.0
-    jest-util: ^29.7.0
-  checksum: caf2bbd11f71c9241b458d1b5a66cbe95debc5a15d96442444b5d5c7ba774f523c76627c6931cca5e10e76f0d08761f6f1f01a608898f4751a0eee54fc3d8d00
-  languageName: node
-  linkType: hard
-
-"@jest/globals@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/globals@npm:29.7.0"
-  dependencies:
-    "@jest/environment": ^29.7.0
-    "@jest/expect": ^29.7.0
-    "@jest/types": ^29.6.3
-    jest-mock: ^29.7.0
-  checksum: 97dbb9459135693ad3a422e65ca1c250f03d82b2a77f6207e7fa0edd2c9d2015fbe4346f3dc9ebff1678b9d8da74754d4d440b7837497f8927059c0642a22123
-  languageName: node
-  linkType: hard
-
-"@jest/reporters@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/reporters@npm:29.7.0"
-  dependencies:
-    "@bcoe/v8-coverage": ^0.2.3
-    "@jest/console": ^29.7.0
-    "@jest/test-result": ^29.7.0
-    "@jest/transform": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@jridgewell/trace-mapping": ^0.3.18
-    "@types/node": "*"
-    chalk: ^4.0.0
-    collect-v8-coverage: ^1.0.0
-    exit: ^0.1.2
-    glob: ^7.1.3
-    graceful-fs: ^4.2.9
-    istanbul-lib-coverage: ^3.0.0
-    istanbul-lib-instrument: ^6.0.0
-    istanbul-lib-report: ^3.0.0
-    istanbul-lib-source-maps: ^4.0.0
-    istanbul-reports: ^3.1.3
-    jest-message-util: ^29.7.0
-    jest-util: ^29.7.0
-    jest-worker: ^29.7.0
-    slash: ^3.0.0
-    string-length: ^4.0.1
-    strip-ansi: ^6.0.0
-    v8-to-istanbul: ^9.0.1
-  peerDependencies:
-    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  checksum: 7eadabd62cc344f629024b8a268ecc8367dba756152b761bdcb7b7e570a3864fc51b2a9810cd310d85e0a0173ef002ba4528d5ea0329fbf66ee2a3ada9c40455
-  languageName: node
-  linkType: hard
-
 "@jest/schemas@npm:^29.6.3":
   version: 29.6.3
   resolution: "@jest/schemas@npm:29.6.3"
   dependencies:
     "@sinclair/typebox": ^0.27.8
   checksum: 910040425f0fc93cd13e68c750b7885590b8839066dfa0cd78e7def07bbb708ad869381f725945d66f2284de5663bbecf63e8fdd856e2ae6e261ba30b1687e93
-  languageName: node
-  linkType: hard
-
-"@jest/source-map@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "@jest/source-map@npm:29.6.3"
-  dependencies:
-    "@jridgewell/trace-mapping": ^0.3.18
-    callsites: ^3.0.0
-    graceful-fs: ^4.2.9
-  checksum: bcc5a8697d471396c0003b0bfa09722c3cd879ad697eb9c431e6164e2ea7008238a01a07193dfe3cbb48b1d258eb7251f6efcea36f64e1ebc464ea3c03ae2deb
-  languageName: node
-  linkType: hard
-
-"@jest/test-result@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/test-result@npm:29.7.0"
-  dependencies:
-    "@jest/console": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/istanbul-lib-coverage": ^2.0.0
-    collect-v8-coverage: ^1.0.0
-  checksum: 67b6317d526e335212e5da0e768e3b8ab8a53df110361b80761353ad23b6aea4432b7c5665bdeb87658ea373b90fb1afe02ed3611ef6c858c7fba377505057fa
-  languageName: node
-  linkType: hard
-
-"@jest/test-sequencer@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/test-sequencer@npm:29.7.0"
-  dependencies:
-    "@jest/test-result": ^29.7.0
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^29.7.0
-    slash: ^3.0.0
-  checksum: 73f43599017946be85c0b6357993b038f875b796e2f0950487a82f4ebcb115fa12131932dd9904026b4ad8be131fe6e28bd8d0aa93b1563705185f9804bff8bd
-  languageName: node
-  linkType: hard
-
-"@jest/transform@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "@jest/transform@npm:29.7.0"
-  dependencies:
-    "@babel/core": ^7.11.6
-    "@jest/types": ^29.6.3
-    "@jridgewell/trace-mapping": ^0.3.18
-    babel-plugin-istanbul: ^6.1.1
-    chalk: ^4.0.0
-    convert-source-map: ^2.0.0
-    fast-json-stable-stringify: ^2.1.0
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^29.7.0
-    jest-regex-util: ^29.6.3
-    jest-util: ^29.7.0
-    micromatch: ^4.0.4
-    pirates: ^4.0.4
-    slash: ^3.0.0
-    write-file-atomic: ^4.0.2
-  checksum: 0f8ac9f413903b3cb6d240102db848f2a354f63971ab885833799a9964999dd51c388162106a807f810071f864302cdd8e3f0c241c29ce02d85a36f18f3f40ab
   languageName: node
   linkType: hard
 
@@ -4190,7 +3985,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: c2e36e67971f719a8a3a85ef5a5f580622437cc723c35d03ebd0c9c0b06418700ef006f58af742791f71f6a4fc68fcfaf1f6a74ec2f9a3332860e9373459dae7
@@ -4207,7 +4002,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/trace-mapping@npm:^0.3.12, @jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.9":
+"@jridgewell/trace-mapping@npm:^0.3.18, @jridgewell/trace-mapping@npm:^0.3.24, @jridgewell/trace-mapping@npm:^0.3.25, @jridgewell/trace-mapping@npm:^0.3.28, @jridgewell/trace-mapping@npm:^0.3.9":
   version: 0.3.30
   resolution: "@jridgewell/trace-mapping@npm:0.3.30"
   dependencies:
@@ -4707,21 +4502,19 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@lidofinance/lido-ethereum-sdk@workspace:packages/sdk"
   dependencies:
-    "@jest/globals": ^29.7.0
     "@openzeppelin/merkle-tree": ^1.0.8
     "@types/fs-extra": ^11.0.1
+    "@viem/anvil": ^0.0.10
     blockstore-core: ^5.0.4
     dotenv: ^16.3.1
     fs-extra: ^11.1.1
-    ganache: ^7.9.2
     graphql: ^16.8.1
     graphql-request: ^6.1.0
     ipfs-unixfs-importer: ^15.4.0
-    jest: ^29.7.0
     multiformats: ^13.4.0
     rimraf: ^5.0.1
-    ts-jest: ^29.1.2
     typescript: ^5.4.5
+    vitest: ^2.1.0
   peerDependencies:
     viem: ^2.45.0
   languageName: unknown
@@ -6519,6 +6312,181 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rollup/rollup-android-arm-eabi@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.60.0"
+  conditions: os=android & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-android-arm64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.60.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-arm64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.60.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-darwin-x64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.60.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-arm64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-freebsd-arm64@npm:4.60.0"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-freebsd-x64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-freebsd-x64@npm:4.60.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.60.0"
+  conditions: os=linux & cpu=arm & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm-musleabihf@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.60.0"
+  conditions: os=linux & cpu=arm & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.60.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-arm64-musl@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.60.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-loong64-gnu@npm:4.60.0"
+  conditions: os=linux & cpu=loong64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-loong64-musl@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-loong64-musl@npm:4.60.0"
+  conditions: os=linux & cpu=loong64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-ppc64-gnu@npm:4.60.0"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-ppc64-musl@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-ppc64-musl@npm:4.60.0"
+  conditions: os=linux & cpu=ppc64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.60.0"
+  conditions: os=linux & cpu=riscv64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-riscv64-musl@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-riscv64-musl@npm:4.60.0"
+  conditions: os=linux & cpu=riscv64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-s390x-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.60.0"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.60.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-linux-x64-musl@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.60.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openbsd-x64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-openbsd-x64@npm:4.60.0"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-openharmony-arm64@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-openharmony-arm64@npm:4.60.0"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-arm64-msvc@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.60.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-ia32-msvc@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.60.0"
+  conditions: os=win32 & cpu=ia32
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-gnu@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-win32-x64-gnu@npm:4.60.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rollup/rollup-win32-x64-msvc@npm:4.60.0":
+  version: 4.60.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.60.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@safe-global/safe-apps-provider@npm:0.18.5":
   version: 0.18.5
   resolution: "@safe-global/safe-apps-provider@npm:0.18.5"
@@ -6812,24 +6780,6 @@ __metadata:
   version: 2.3.0
   resolution: "@sindresorhus/merge-streams@npm:2.3.0"
   checksum: e989d53dee68d7e49b4ac02ae49178d561c461144cea83f66fa91ff012d981ad0ad2340cbd13f2fdb57989197f5c987ca22a74eb56478626f04e79df84291159
-  languageName: node
-  linkType: hard
-
-"@sinonjs/commons@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@sinonjs/commons@npm:3.0.1"
-  dependencies:
-    type-detect: 4.0.8
-  checksum: a7c3e7cc612352f4004873747d9d8b2d4d90b13a6d483f685598c945a70e734e255f1ca5dc49702515533c403b32725defff148177453b3f3915bcb60e9d4601
-  languageName: node
-  linkType: hard
-
-"@sinonjs/fake-timers@npm:^10.0.2":
-  version: 10.3.0
-  resolution: "@sinonjs/fake-timers@npm:10.3.0"
-  dependencies:
-    "@sinonjs/commons": ^3.0.0
-  checksum: 614d30cb4d5201550c940945d44c9e0b6d64a888ff2cd5b357f95ad6721070d6b8839cd10e15b76bf5e14af0bcc1d8f9ec00d49a46318f1f669a4bec1d7f3148
   languageName: node
   linkType: hard
 
@@ -7315,32 +7265,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@trufflesuite/bigint-buffer@npm:1.1.10":
-  version: 1.1.10
-  resolution: "@trufflesuite/bigint-buffer@npm:1.1.10"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: 4.4.0
-  checksum: e1dc5e4fbf348a55e660c0055267021eb04cbbdb7f6b0ee983ad32cd4aae1200be448a2ca3963c7d19c7c936d42f66c1ff8b5e4e2332cb1a9e3f870ff818dce4
-  languageName: node
-  linkType: hard
-
-"@trufflesuite/uws-js-unofficial@npm:20.30.0-unofficial.0":
-  version: 20.30.0-unofficial.0
-  resolution: "@trufflesuite/uws-js-unofficial@npm:20.30.0-unofficial.0"
-  dependencies:
-    bufferutil: 4.0.7
-    utf-8-validate: 6.0.3
-    ws: 8.13.0
-  dependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 67e67140877f89b31c504a057d26853d5780b09c733d92c32480d2f0dfe4e98fb822860f3efeb06f379daecee70d67185f88a7b6f3406d18526e501b36c40fd3
-  languageName: node
-  linkType: hard
-
 "@trysound/sax@npm:0.2.0":
   version: 0.2.0
   resolution: "@trysound/sax@npm:0.2.0"
@@ -7399,56 +7323,6 @@ __metadata:
   dependencies:
     "@types/estree": "*"
   checksum: 60e1fd28af18d6cb54a93a7231c7c18774a9a8739c9b179e9e8750dca631e10cbef2d82b02830ea3f557b1d121e6406441e9e1250bd492dc81d4b3456e76e4d4
-  languageName: node
-  linkType: hard
-
-"@types/babel__core@npm:^7.1.14":
-  version: 7.20.5
-  resolution: "@types/babel__core@npm:7.20.5"
-  dependencies:
-    "@babel/parser": ^7.20.7
-    "@babel/types": ^7.20.7
-    "@types/babel__generator": "*"
-    "@types/babel__template": "*"
-    "@types/babel__traverse": "*"
-  checksum: a3226f7930b635ee7a5e72c8d51a357e799d19cbf9d445710fa39ab13804f79ab1a54b72ea7d8e504659c7dfc50675db974b526142c754398d7413aa4bc30845
-  languageName: node
-  linkType: hard
-
-"@types/babel__generator@npm:*":
-  version: 7.6.8
-  resolution: "@types/babel__generator@npm:7.6.8"
-  dependencies:
-    "@babel/types": ^7.0.0
-  checksum: 5b332ea336a2efffbdeedb92b6781949b73498606ddd4205462f7d96dafd45ff3618770b41de04c4881e333dd84388bfb8afbdf6f2764cbd98be550d85c6bb48
-  languageName: node
-  linkType: hard
-
-"@types/babel__template@npm:*":
-  version: 7.4.4
-  resolution: "@types/babel__template@npm:7.4.4"
-  dependencies:
-    "@babel/parser": ^7.1.0
-    "@babel/types": ^7.0.0
-  checksum: d7a02d2a9b67e822694d8e6a7ddb8f2b71a1d6962dfd266554d2513eefbb205b33ca71a0d163b1caea3981ccf849211f9964d8bd0727124d18ace45aa6c9ae29
-  languageName: node
-  linkType: hard
-
-"@types/babel__traverse@npm:*, @types/babel__traverse@npm:^7.0.6":
-  version: 7.20.5
-  resolution: "@types/babel__traverse@npm:7.20.5"
-  dependencies:
-    "@babel/types": ^7.20.7
-  checksum: 608e0ab4fc31cd47011d98942e6241b34d461608c0c0e153377c5fd822c436c475f1ded76a56bfa76a1adf8d9266b727bbf9bfac90c4cb152c97f30dadc5b7e8
-  languageName: node
-  linkType: hard
-
-"@types/bn.js@npm:^5.1.0":
-  version: 5.1.5
-  resolution: "@types/bn.js@npm:5.1.5"
-  dependencies:
-    "@types/node": "*"
-  checksum: c87b28c4af74545624f8a3dae5294b16aa190c222626e8d4b2e327b33b1a3f1eeb43e7a24d914a9774bca43d8cd6e1cb0325c1f4b3a244af6693a024e1d918e6
   languageName: node
   linkType: hard
 
@@ -7800,7 +7674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
+"@types/estree@npm:*, @types/estree@npm:1.0.8, @types/estree@npm:^1.0.0, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: bd93e2e415b6f182ec4da1074e1f36c480f1d26add3e696d54fb30c09bc470897e41361c8fd957bf0985024f8fbf1e6e2aff977d79352ef7eb93a5c6dcff6c11
@@ -7871,15 +7745,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/graceful-fs@npm:^4.1.3":
-  version: 4.1.9
-  resolution: "@types/graceful-fs@npm:4.1.9"
-  dependencies:
-    "@types/node": "*"
-  checksum: 79d746a8f053954bba36bd3d94a90c78de995d126289d656fb3271dd9f1229d33f678da04d10bce6be440494a5a73438e2e363e92802d16b8315b051036c5256
-  languageName: node
-  linkType: hard
-
 "@types/gtag.js@npm:^0.0.12":
   version: 0.0.12
   resolution: "@types/gtag.js@npm:0.0.12"
@@ -7943,7 +7808,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0, @types/istanbul-lib-coverage@npm:^2.0.1":
+"@types/istanbul-lib-coverage@npm:*, @types/istanbul-lib-coverage@npm:^2.0.0":
   version: 2.0.6
   resolution: "@types/istanbul-lib-coverage@npm:2.0.6"
   checksum: 3feac423fd3e5449485afac999dcfcb3d44a37c830af898b689fadc65d26526460bedb889db278e0d4d815a670331796494d073a10ee6e3a6526301fe7415778
@@ -7988,13 +7853,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: 309fda20eb5f1cf68f2df28931afdf189c5e7e6bec64ac783ce737bb98908d57f6f58757ad5da9be37b815645a6f914e2d4f3ac66c574b8fe1ba6616284d0e97
-  languageName: node
-  linkType: hard
-
-"@types/lru-cache@npm:5.1.1":
-  version: 5.1.1
-  resolution: "@types/lru-cache@npm:5.1.1"
-  checksum: e1d6c0085f61b16ec5b3073ec76ad1be4844ea036561c3f145fc19f71f084b58a6eb600b14128aa95809d057d28f1d147c910186ae51219f58366ffd2ff2e118
   languageName: node
   linkType: hard
 
@@ -8195,13 +8053,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/seedrandom@npm:3.0.1":
-  version: 3.0.1
-  resolution: "@types/seedrandom@npm:3.0.1"
-  checksum: d9755452f224a4f5072a1d8738da6c9de3039fc59a2a449b1f658e51087be7b48ada49bcabc8b0f16633c095f55598c32fcd072c448858422a2f6a0566569e4c
-  languageName: node
-  linkType: hard
-
 "@types/semver@npm:^7.3.12, @types/semver@npm:^7.5.0":
   version: 7.5.8
   resolution: "@types/semver@npm:7.5.8"
@@ -8245,13 +8096,6 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: b4b5381122465d80ea8b158537c00bc82317222d3fb31fd7229ff25b31fa89134abfbab969118da55622236bf3d8fee75759f3959908b5688991f492008f29bc
-  languageName: node
-  linkType: hard
-
-"@types/stack-utils@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "@types/stack-utils@npm:2.0.3"
-  checksum: 72576cc1522090fe497337c2b99d9838e320659ac57fa5560fcbdcbafcf5d0216c6b3a0a8a4ee4fdb3b1f5e3420aa4f6223ab57b82fef3578bec3206425c6cf5
   languageName: node
   linkType: hard
 
@@ -8514,6 +8358,99 @@ __metadata:
   version: 1.3.0
   resolution: "@ungap/structured-clone@npm:1.3.0"
   checksum: 64ed518f49c2b31f5b50f8570a1e37bde3b62f2460042c50f132430b2d869c4a6586f13aa33a58a4722715b8158c68cae2827389d6752ac54da2893c83e480fc
+  languageName: node
+  linkType: hard
+
+"@viem/anvil@npm:^0.0.10":
+  version: 0.0.10
+  resolution: "@viem/anvil@npm:0.0.10"
+  dependencies:
+    execa: ^7.1.1
+    get-port: ^6.1.2
+    http-proxy: ^1.18.1
+    ws: ^8.13.0
+  checksum: fb475055f36c753cea26fa0c02a0278301dddcdc8003418576395cfc31e97ba5a236fbc66ff093bd8d39ea05286487adb86b7499308e446b6cfe90dc08089b38
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/expect@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": 2.1.9
+    "@vitest/utils": 2.1.9
+    chai: ^5.1.2
+    tinyrainbow: ^1.2.0
+  checksum: a234f96dd42c76e20af68b2ad2f00b80a3873501d5daa524bf1405b344e86123716b925f976d8104fd242bfbd0d9cf7084d0eb4a690097e6e5db456d220ed67a
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/mocker@npm:2.1.9"
+  dependencies:
+    "@vitest/spy": 2.1.9
+    estree-walker: ^3.0.3
+    magic-string: ^0.30.12
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^5.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 17de391acc4d899f15356b45cde8202e5d5ca4517c32c0c9dcf32ce0660501773fdc29675b4f7d48c1579a560ac41f8f5181ebe41a7daf675f561d611e8e30dc
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:2.1.9, @vitest/pretty-format@npm:^2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/pretty-format@npm:2.1.9"
+  dependencies:
+    tinyrainbow: ^1.2.0
+  checksum: 33f7ff0a9d356ddd6534390a0aea260dc04a3022a94901c87d141bacf71d2b3fff2e3bf08a55dd424c5355fd3b41656cb7871c76372fef45ffac1ea89d0dc508
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/runner@npm:2.1.9"
+  dependencies:
+    "@vitest/utils": 2.1.9
+    pathe: ^1.1.2
+  checksum: d8aaadc98bcbe1ee7c832a7d619d3c77d3c67536f10b80a3106d9d6e03ecc0f5467ef7bd4a65a07fe924cc166fe7415d637b2b08ef71e1a208a250543f9f3545
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/snapshot@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": 2.1.9
+    magic-string: ^0.30.12
+    pathe: ^1.1.2
+  checksum: fb693dea59709c9df8660e5948c7971d2c3ce74212eafa7d542a578bbb8aed203dc03129dd5e476251e1946b50432e79a4fd59069fd4f950283e188167b9496d
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/spy@npm:2.1.9"
+  dependencies:
+    tinyspy: ^3.0.2
+  checksum: f9279488b5d2a27800e33e8fe51cc685b2a0db49d30b80b2b0cc924f8b1736eb520459c6e8bd09fa4457f5bb86ff073e7bdcf60d36452c11a8a8f9cbc8030237
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:2.1.9":
+  version: 2.1.9
+  resolution: "@vitest/utils@npm:2.1.9"
+  dependencies:
+    "@vitest/pretty-format": 2.1.9
+    loupe: ^3.1.2
+    tinyrainbow: ^1.2.0
+  checksum: b24fb9c6765801f2e0578ad5c32fadf9541a833301eaed2877a427096cf05214244b361f94eda80be2b9c841f58ae3c67d37dedc5a902b2cb44041979bae4d8f
   languageName: node
   linkType: hard
 
@@ -9133,35 +9070,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abstract-level@npm:1.0.3":
-  version: 1.0.3
-  resolution: "abstract-level@npm:1.0.3"
-  dependencies:
-    buffer: ^6.0.3
-    catering: ^2.1.0
-    is-buffer: ^2.0.5
-    level-supports: ^4.0.0
-    level-transcoder: ^1.0.1
-    module-error: ^1.0.1
-    queue-microtask: ^1.2.3
-  checksum: 70d61a3924526ebc257b138992052f9ff571a6cee5a7660836e37a1cc7081273c3acf465dd2f5e1897b38dc743a6fd9dba14a5d8a2a9d39e5787cd3da99f301d
-  languageName: node
-  linkType: hard
-
-"abstract-leveldown@npm:7.2.0, abstract-leveldown@npm:^7.2.0":
-  version: 7.2.0
-  resolution: "abstract-leveldown@npm:7.2.0"
-  dependencies:
-    buffer: ^6.0.3
-    catering: ^2.0.0
-    is-buffer: ^2.0.5
-    level-concat-iterator: ^3.0.0
-    level-supports: ^2.0.1
-    queue-microtask: ^1.2.3
-  checksum: d558111f2d123da95ac80b8ba3b9b0a5bc8cd87296e64b05dca693f5f4839aa0e2fc97bad56a101766f499824e2962611750f8a76bbac4a5db35801968fbbe02
-  languageName: node
-  linkType: hard
-
 "abstract-logging@npm:^2.0.1":
   version: 2.0.1
   resolution: "abstract-logging@npm:2.0.1"
@@ -9397,7 +9305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-escapes@npm:^4.2.1, ansi-escapes@npm:^4.3.2":
+"ansi-escapes@npm:^4.3.2":
   version: 4.3.2
   resolution: "ansi-escapes@npm:4.3.2"
   dependencies:
@@ -9456,13 +9364,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.0.0":
-  version: 5.2.0
-  resolution: "ansi-styles@npm:5.2.0"
-  checksum: d7f4e97ce0623aea6bc0d90dcd28881ee04cba06c570b97fd3391bd7a268eedfd9d5e2dd4fdcbdd82b8105df5faf6f24aaedc08eaf3da898e702db5948f63469
-  languageName: node
-  linkType: hard
-
 "ansi-styles@npm:^6.1.0":
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
@@ -9477,7 +9378,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"anymatch@npm:^3.0.3, anymatch@npm:^3.1.3, anymatch@npm:~3.1.2":
+"anymatch@npm:^3.1.3, anymatch@npm:~3.1.2":
   version: 3.1.3
   resolution: "anymatch@npm:3.1.3"
   dependencies:
@@ -9712,6 +9613,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: a0789dd882211b87116e81e2648ccb7f60340b34f19877dd020b39ebb4714e475eb943e14ba3e22201c221ef6645b7bfe10297e76b6ac95b48a9898c1211ce66
+  languageName: node
+  linkType: hard
+
 "ast-types-flow@npm:^0.0.8":
   version: 0.0.8
   resolution: "ast-types-flow@npm:0.0.8"
@@ -9725,15 +9633,6 @@ __metadata:
   bin:
     astring: bin/astring
   checksum: 6f034d2acef1dac8bb231e7cc26c573d3c14e1975ea6e04f20312b43d4f462f963209bc64187d25d477a182dc3c33277959a0156ab7a3617aa79b1eac4d88e1f
-  languageName: node
-  linkType: hard
-
-"async-eventemitter@npm:0.2.4":
-  version: 0.2.4
-  resolution: "async-eventemitter@npm:0.2.4"
-  dependencies:
-    async: ^2.4.0
-  checksum: b9e77e0f58ebd7188c50c23d613d1263e0ab501f5e677e02b57cc97d7032beaf60aafa189887e7105569c791e212df4af00b608be1e9a4c425911d577124911e
   languageName: node
   linkType: hard
 
@@ -9757,15 +9656,6 @@ __metadata:
   dependencies:
     tslib: ^2.0.0
   checksum: f50102e0c57f6a958528cff7dff13da070897f17107b42274417a7248905b927b6e51c3387f8aed1f5cd6005b0e692d64a83a0789be602e4e7e7da4afe08b889
-  languageName: node
-  linkType: hard
-
-"async@npm:^2.4.0":
-  version: 2.6.4
-  resolution: "async@npm:2.6.4"
-  dependencies:
-    lodash: ^4.17.14
-  checksum: a52083fb32e1ebe1d63e5c5624038bb30be68ff07a6c8d7dfe35e47c93fc144bd8652cbec869e0ac07d57dde387aa5f1386be3559cdee799cb1f789678d88e19
   languageName: node
   linkType: hard
 
@@ -9856,23 +9746,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"babel-jest@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "babel-jest@npm:29.7.0"
-  dependencies:
-    "@jest/transform": ^29.7.0
-    "@types/babel__core": ^7.1.14
-    babel-plugin-istanbul: ^6.1.1
-    babel-preset-jest: ^29.6.3
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    slash: ^3.0.0
-  peerDependencies:
-    "@babel/core": ^7.8.0
-  checksum: ee6f8e0495afee07cac5e4ee167be705c711a8cc8a737e05a587a131fdae2b3c8f9aa55dfd4d9c03009ac2d27f2de63d8ba96d3e8460da4d00e8af19ef9a83f7
-  languageName: node
-  linkType: hard
-
 "babel-loader@npm:^9.2.1":
   version: 9.2.1
   resolution: "babel-loader@npm:9.2.1"
@@ -9892,31 +9765,6 @@ __metadata:
   dependencies:
     object.assign: ^4.1.0
   checksum: c9d24415bcc608d0db7d4c8540d8002ac2f94e2573d2eadced137a29d9eab7e25d2cbb4bc6b9db65cf6ee7430f7dd011d19c911a9a778f0533b4a05ce8292c9b
-  languageName: node
-  linkType: hard
-
-"babel-plugin-istanbul@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "babel-plugin-istanbul@npm:6.1.1"
-  dependencies:
-    "@babel/helper-plugin-utils": ^7.0.0
-    "@istanbuljs/load-nyc-config": ^1.0.0
-    "@istanbuljs/schema": ^0.1.2
-    istanbul-lib-instrument: ^5.0.4
-    test-exclude: ^6.0.0
-  checksum: cb4fd95738219f232f0aece1116628cccff16db891713c4ccb501cddbbf9272951a5df81f2f2658dfdf4b3e7b236a9d5cbcf04d5d8c07dd5077297339598061a
-  languageName: node
-  linkType: hard
-
-"babel-plugin-jest-hoist@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "babel-plugin-jest-hoist@npm:29.6.3"
-  dependencies:
-    "@babel/template": ^7.3.3
-    "@babel/types": ^7.3.3
-    "@types/babel__core": ^7.1.14
-    "@types/babel__traverse": ^7.0.6
-  checksum: 51250f22815a7318f17214a9d44650ba89551e6d4f47a2dc259128428324b52f5a73979d010cefd921fd5a720d8c1d55ad74ff601cd94c7bd44d5f6292fde2d1
   languageName: node
   linkType: hard
 
@@ -9968,40 +9816,6 @@ __metadata:
   peerDependencies:
     styled-components: ">= 2"
   checksum: d791aed68d975dae4f73055f86cd47afa99cb402b8113acdaf5678c8b6fba2cbc15543f2debe8ed09becb198aae8be2adfe268ad41f4bca917288e073a622bf8
-  languageName: node
-  linkType: hard
-
-"babel-preset-current-node-syntax@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "babel-preset-current-node-syntax@npm:1.0.1"
-  dependencies:
-    "@babel/plugin-syntax-async-generators": ^7.8.4
-    "@babel/plugin-syntax-bigint": ^7.8.3
-    "@babel/plugin-syntax-class-properties": ^7.8.3
-    "@babel/plugin-syntax-import-meta": ^7.8.3
-    "@babel/plugin-syntax-json-strings": ^7.8.3
-    "@babel/plugin-syntax-logical-assignment-operators": ^7.8.3
-    "@babel/plugin-syntax-nullish-coalescing-operator": ^7.8.3
-    "@babel/plugin-syntax-numeric-separator": ^7.8.3
-    "@babel/plugin-syntax-object-rest-spread": ^7.8.3
-    "@babel/plugin-syntax-optional-catch-binding": ^7.8.3
-    "@babel/plugin-syntax-optional-chaining": ^7.8.3
-    "@babel/plugin-syntax-top-level-await": ^7.8.3
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: d118c2742498c5492c095bc8541f4076b253e705b5f1ad9a2e7d302d81a84866f0070346662355c8e25fc02caa28dc2da8d69bcd67794a0d60c4d6fab6913cc8
-  languageName: node
-  linkType: hard
-
-"babel-preset-jest@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "babel-preset-jest@npm:29.6.3"
-  dependencies:
-    babel-plugin-jest-hoist: ^29.6.3
-    babel-preset-current-node-syntax: ^1.0.0
-  peerDependencies:
-    "@babel/core": ^7.0.0
-  checksum: aa4ff2a8a728d9d698ed521e3461a109a1e66202b13d3494e41eea30729a5e7cc03b3a2d56c594423a135429c37bf63a9fa8b0b9ce275298be3095a88c69f6fb
   languageName: node
   linkType: hard
 
@@ -10298,15 +10112,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bs-logger@npm:0.x":
-  version: 0.2.6
-  resolution: "bs-logger@npm:0.2.6"
-  dependencies:
-    fast-json-stable-stringify: 2.x
-  checksum: d34bdaf68c64bd099ab97c3ea608c9ae7d3f5faa1178b3f3f345acd94e852e608b2d4f9103fb2e503f5e69780e98293df41691b84be909b41cf5045374d54606
-  languageName: node
-  linkType: hard
-
 "bs58@npm:6.0.0":
   version: 6.0.0
   resolution: "bs58@npm:6.0.0"
@@ -10336,15 +10141,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bser@npm:2.1.1":
-  version: 2.1.1
-  resolution: "bser@npm:2.1.1"
-  dependencies:
-    node-int64: ^0.4.0
-  checksum: 9ba4dc58ce86300c862bffc3ae91f00b2a03b01ee07f3564beeeaf82aa243b8b03ba53f123b0b842c190d4399b94697970c8e7cf7b1ea44b61aa28c3526a4449
-  languageName: node
-  linkType: hard
-
 "buffer-from@npm:^1.0.0":
   version: 1.1.2
   resolution: "buffer-from@npm:1.1.2"
@@ -10359,26 +10155,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.2.1
   checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
-  languageName: node
-  linkType: hard
-
-"bufferutil@npm:4.0.5":
-  version: 4.0.5
-  resolution: "bufferutil@npm:4.0.5"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 37d5bef7cb38d29f9377b8891ff8a57f53ae6057313d77a8aa2a7417df37a72f16987100796cb2f1e1862f3eb80057705f3c052615ec076a0dcc7aa6c83b68c9
-  languageName: node
-  linkType: hard
-
-"bufferutil@npm:4.0.7":
-  version: 4.0.7
-  resolution: "bufferutil@npm:4.0.7"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: f75aa87e3d1b99b87a95f60a855e63f70af07b57fb8443e75a2ddfef2e47788d130fdd46e3a78fd7e0c10176082b26dfbed970c5b8632e1cc299cafa0e93ce45
   languageName: node
   linkType: hard
 
@@ -10444,6 +10220,13 @@ __metadata:
   version: 2.0.1
   resolution: "bytestreamjs@npm:2.0.1"
   checksum: db4cb039794675a0ec1f097d228e4897378cdf5f794dca04fc3bff63efb466524fcfac95e59e89e928822a80fad7574734c02b8eace9e841d8599da43c82768a
+  languageName: node
+  linkType: hard
+
+"cac@npm:^6.7.14":
+  version: 6.7.14
+  resolution: "cac@npm:6.7.14"
+  checksum: 45a2496a9443abbe7f52a49b22fbe51b1905eff46e03fd5e6c98e3f85077be3f8949685a1849b1a9cd2bc3e5567dfebcf64f01ce01847baf918f1b37c839791a
   languageName: node
   linkType: hard
 
@@ -10654,13 +10437,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"catering@npm:^2.0.0, catering@npm:^2.1.0":
-  version: 2.1.1
-  resolution: "catering@npm:2.1.1"
-  checksum: 205daefa69c935b0c19f3d8f2e0a520dd69aebe9bda55902958003f7c9cff8f967dfb90071b421bd6eb618576f657a89d2bc0986872c9bc04bbd66655e9d4bd6
-  languageName: node
-  linkType: hard
-
 "cbw-sdk@npm:@coinbase/wallet-sdk@3.9.3":
   version: 3.9.3
   resolution: "@coinbase/wallet-sdk@npm:3.9.3"
@@ -10682,6 +10458,19 @@ __metadata:
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
   checksum: 48193dada54c9e260e0acf57fc16171a225305548f9ad20d5471e0f7a8c026aedd8747091dccb0d900cde7df4e4ddbd235df0d8de4a64c71b12f0d3303eeafd4
+  languageName: node
+  linkType: hard
+
+"chai@npm:^5.1.2":
+  version: 5.3.3
+  resolution: "chai@npm:5.3.3"
+  dependencies:
+    assertion-error: ^2.0.1
+    check-error: ^2.1.1
+    deep-eql: ^5.0.1
+    loupe: ^3.1.0
+    pathval: ^2.0.0
+  checksum: bc4091f1cccfee63f6a3d02ce477fe847f5c57e747916a11bd72675c9459125084e2e55dc2363ee2b82b088a878039ee7ee27c75d6d90f7de9202bf1b12ce573
   languageName: node
   linkType: hard
 
@@ -10745,6 +10534,13 @@ __metadata:
   version: 2.0.1
   resolution: "character-reference-invalid@npm:2.0.1"
   checksum: 98d3b1a52ae510b7329e6ee7f6210df14f1e318c5415975d4c9e7ee0ef4c07875d47c6e74230c64551f12f556b4a8ccc24d9f3691a2aa197019e72a95e9297ee
+  languageName: node
+  linkType: hard
+
+"check-error@npm:^2.1.1":
+  version: 2.1.3
+  resolution: "check-error@npm:2.1.3"
+  checksum: f1868d3db60f5a7da92e140ccf33e9152bf6124161fa9b7a4ae8eafdb05e66e1f13570401e56f314f037b0f1b71eaf38ad0c7256310d82c6105e9d85ded0f202
   languageName: node
   linkType: hard
 
@@ -10867,13 +10663,6 @@ __metadata:
   dependencies:
     consola: ^3.2.3
   checksum: 3fbcaaea92d328deddb5aba7d629d9076d4f1aa0338f59db7ea647a8f51eedc14b7f6218c87ad03c9e3c126213ba87d13d7774f9c30d64209f4b074aa83bd6ab
-  languageName: node
-  linkType: hard
-
-"cjs-module-lexer@npm:^1.0.0":
-  version: 1.2.3
-  resolution: "cjs-module-lexer@npm:1.2.3"
-  checksum: 5ea3cb867a9bb609b6d476cd86590d105f3cfd6514db38ff71f63992ab40939c2feb68967faa15a6d2b1f90daa6416b79ea2de486e9e2485a6f8b66a21b4fb0a
   languageName: node
   linkType: hard
 
@@ -11027,24 +10816,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"co@npm:^4.6.0":
-  version: 4.6.0
-  resolution: "co@npm:4.6.0"
-  checksum: 5210d9223010eb95b29df06a91116f2cf7c8e0748a9013ed853b53f362ea0e822f1e5bb054fb3cefc645239a4cf966af1f6133a3b43f40d591f3b68ed6cf0510
-  languageName: node
-  linkType: hard
-
 "collapse-white-space@npm:^2.0.0":
   version: 2.1.0
   resolution: "collapse-white-space@npm:2.1.0"
   checksum: c8978b1f4e7d68bf846cfdba6c6689ce8910511df7d331eb6e6757e51ceffb52768d59a28db26186c91dcf9594955b59be9f8ccd473c485790f5d8b90dc6726f
-  languageName: node
-  linkType: hard
-
-"collect-v8-coverage@npm:^1.0.0":
-  version: 1.0.2
-  resolution: "collect-v8-coverage@npm:1.0.2"
-  checksum: c10f41c39ab84629d16f9f6137bc8a63d332244383fc368caf2d2052b5e04c20cd1fd70f66fcf4e2422b84c8226598b776d39d5f2d2a51867cc1ed5d1982b4da
   languageName: node
   linkType: hard
 
@@ -11556,23 +11331,6 @@ __metadata:
     ripemd160: ^2.0.1
     sha.js: ^2.4.0
   checksum: 02a6ae3bb9cd4afee3fabd846c1d8426a0e6b495560a977ba46120c473cb283be6aa1cace76b5f927cf4e499c6146fb798253e48e83d522feba807d6b722eaa9
-  languageName: node
-  linkType: hard
-
-"create-jest@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "create-jest@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    chalk: ^4.0.0
-    exit: ^0.1.2
-    graceful-fs: ^4.2.9
-    jest-config: ^29.7.0
-    jest-util: ^29.7.0
-    prompts: ^2.0.1
-  bin:
-    create-jest: bin/create-jest.js
-  checksum: 1427d49458adcd88547ef6fa39041e1fe9033a661293aa8d2c3aa1b4967cb5bf4f0c00436c7a61816558f28ba2ba81a94d5c962e8022ea9a883978fc8e1f2945
   languageName: node
   linkType: hard
 
@@ -12405,6 +12163,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.7":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 4805abd570e601acdca85b6aa3757186084a45cff9b2fa6eee1f3b173caa776b45f478b2a71a572d616d2010cea9211d0ac4a02a610e4c18ac4324bde3760834
+  languageName: node
+  linkType: hard
+
 "debug@npm:~4.3.1, debug@npm:~4.3.2":
   version: 4.3.5
   resolution: "debug@npm:4.3.5"
@@ -12459,15 +12229,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dedent@npm:^1.0.0":
-  version: 1.5.1
-  resolution: "dedent@npm:1.5.1"
-  peerDependencies:
-    babel-plugin-macros: ^3.1.0
-  peerDependenciesMeta:
-    babel-plugin-macros:
-      optional: true
-  checksum: c3c300a14edf1bdf5a873f9e4b22e839d62490bc5c8d6169c1f15858a1a76733d06a9a56930e963d677a2ceeca4b6b0894cc5ea2f501aa382ca5b92af3413c2a
+"deep-eql@npm:^5.0.1":
+  version: 5.0.2
+  resolution: "deep-eql@npm:5.0.2"
+  checksum: 6aaaadb4c19cbce42e26b2bbe5bd92875f599d2602635dc97f0294bae48da79e89470aedee05f449e0ca8c65e9fd7e7872624d1933a1db02713d99c2ca8d1f24
   languageName: node
   linkType: hard
 
@@ -12663,13 +12428,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"detect-newline@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "detect-newline@npm:3.1.0"
-  checksum: ae6cd429c41ad01b164c59ea36f264a2c479598e61cba7c99da24175a7ab80ddf066420f2bec9a1c57a6bead411b4655ff15ad7d281c000a89791f48cbe939e7
-  languageName: node
-  linkType: hard
-
 "detect-newline@npm:^4.0.1":
   version: 4.0.1
   resolution: "detect-newline@npm:4.0.1"
@@ -12703,13 +12461,6 @@ __metadata:
   dependencies:
     dequal: ^2.0.0
   checksum: d2ff650bac0bb6ef08c48f3ba98640bb5fec5cce81e9957eb620408d1bab1204d382a45b785c6b3314dc867bb0684936b84c6867820da6db97cbb5d3c15dd185
-  languageName: node
-  linkType: hard
-
-"diff-sequences@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "diff-sequences@npm:29.6.3"
-  checksum: f4914158e1f2276343d98ff5b31fc004e7304f5470bf0f1adb2ac6955d85a531a6458d33e87667f98f6ae52ebd3891bb47d420bb48a5bd8b7a27ee25b20e33aa
   languageName: node
   linkType: hard
 
@@ -13012,7 +12763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"elliptic@npm:6.5.4, elliptic@npm:^6.5.4":
+"elliptic@npm:6.5.4":
   version: 6.5.4
   resolution: "elliptic@npm:6.5.4"
   dependencies:
@@ -13024,20 +12775,6 @@ __metadata:
     minimalistic-assert: ^1.0.1
     minimalistic-crypto-utils: ^1.0.1
   checksum: d56d21fd04e97869f7ffcc92e18903b9f67f2d4637a23c860492fbbff5a3155fd9ca0184ce0c865dd6eb2487d234ce9551335c021c376cd2d3b7cb749c7d10f4
-  languageName: node
-  linkType: hard
-
-"emittery@npm:0.10.0":
-  version: 0.10.0
-  resolution: "emittery@npm:0.10.0"
-  checksum: 2616a802df51e3f412b9b33f1b43161f7bc96037142cada6ecdbf35ddef1368e30d4f8e47fddc10b0753ccf91d3483b20ebca535b4b1e47526440e13150e2bc7
-  languageName: node
-  linkType: hard
-
-"emittery@npm:^0.13.1":
-  version: 0.13.1
-  resolution: "emittery@npm:0.13.1"
-  checksum: 2b089ab6306f38feaabf4f6f02792f9ec85fc054fda79f44f6790e61bbf6bc4e1616afb9b232e0c5ec5289a8a452f79bfa6d905a6fd64e94b49981f0934001c6
   languageName: node
   linkType: hard
 
@@ -13305,6 +13042,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^1.5.4":
+  version: 1.7.0
+  resolution: "es-module-lexer@npm:1.7.0"
+  checksum: 7858bb76ae387fdbf8a6fccc951bf18919768309850587553eca34698b9193fbc65fab03d3d9f69163d860321fbf66adf89d5821e7f4148c7cb7d7b997259211
+  languageName: node
+  linkType: hard
+
 "es-module-lexer@npm:^2.0.0":
   version: 2.0.0
   resolution: "es-module-lexer@npm:2.0.0"
@@ -13365,6 +13109,86 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild@npm:^0.21.3":
+  version: 0.21.5
+  resolution: "esbuild@npm:0.21.5"
+  dependencies:
+    "@esbuild/aix-ppc64": 0.21.5
+    "@esbuild/android-arm": 0.21.5
+    "@esbuild/android-arm64": 0.21.5
+    "@esbuild/android-x64": 0.21.5
+    "@esbuild/darwin-arm64": 0.21.5
+    "@esbuild/darwin-x64": 0.21.5
+    "@esbuild/freebsd-arm64": 0.21.5
+    "@esbuild/freebsd-x64": 0.21.5
+    "@esbuild/linux-arm": 0.21.5
+    "@esbuild/linux-arm64": 0.21.5
+    "@esbuild/linux-ia32": 0.21.5
+    "@esbuild/linux-loong64": 0.21.5
+    "@esbuild/linux-mips64el": 0.21.5
+    "@esbuild/linux-ppc64": 0.21.5
+    "@esbuild/linux-riscv64": 0.21.5
+    "@esbuild/linux-s390x": 0.21.5
+    "@esbuild/linux-x64": 0.21.5
+    "@esbuild/netbsd-x64": 0.21.5
+    "@esbuild/openbsd-x64": 0.21.5
+    "@esbuild/sunos-x64": 0.21.5
+    "@esbuild/win32-arm64": 0.21.5
+    "@esbuild/win32-ia32": 0.21.5
+    "@esbuild/win32-x64": 0.21.5
+  dependenciesMeta:
+    "@esbuild/aix-ppc64":
+      optional: true
+    "@esbuild/android-arm":
+      optional: true
+    "@esbuild/android-arm64":
+      optional: true
+    "@esbuild/android-x64":
+      optional: true
+    "@esbuild/darwin-arm64":
+      optional: true
+    "@esbuild/darwin-x64":
+      optional: true
+    "@esbuild/freebsd-arm64":
+      optional: true
+    "@esbuild/freebsd-x64":
+      optional: true
+    "@esbuild/linux-arm":
+      optional: true
+    "@esbuild/linux-arm64":
+      optional: true
+    "@esbuild/linux-ia32":
+      optional: true
+    "@esbuild/linux-loong64":
+      optional: true
+    "@esbuild/linux-mips64el":
+      optional: true
+    "@esbuild/linux-ppc64":
+      optional: true
+    "@esbuild/linux-riscv64":
+      optional: true
+    "@esbuild/linux-s390x":
+      optional: true
+    "@esbuild/linux-x64":
+      optional: true
+    "@esbuild/netbsd-x64":
+      optional: true
+    "@esbuild/openbsd-x64":
+      optional: true
+    "@esbuild/sunos-x64":
+      optional: true
+    "@esbuild/win32-arm64":
+      optional: true
+    "@esbuild/win32-ia32":
+      optional: true
+    "@esbuild/win32-x64":
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 2911c7b50b23a9df59a7d6d4cdd3a4f85855787f374dce751148dbb13305e0ce7e880dde1608c2ab7a927fc6cec3587b80995f7fc87a64b455f8b70b55fd8ec1
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.1.1, escalade@npm:^3.2.0":
   version: 3.2.0
   resolution: "escalade@npm:3.2.0"
@@ -13397,13 +13221,6 @@ __metadata:
   version: 1.0.5
   resolution: "escape-string-regexp@npm:1.0.5"
   checksum: 6092fda75c63b110c706b6a9bfde8a612ad595b628f0bd2147eea1d3406723020810e591effc7db1da91d80a71a737a313567c5abb3813e8d9c71f4aa595b410
-  languageName: node
-  linkType: hard
-
-"escape-string-regexp@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "escape-string-regexp@npm:2.0.0"
-  checksum: 9f8a2d5743677c16e85c810e3024d54f0c8dea6424fad3c79ef6666e81dd0846f7437f5e729dfcdac8981bc9e5294c39b4580814d114076b8d36318f46ae4395
   languageName: node
   linkType: hard
 
@@ -13843,7 +13660,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"estree-walker@npm:^3.0.0":
+"estree-walker@npm:^3.0.0, estree-walker@npm:^3.0.3":
   version: 3.0.3
   resolution: "estree-walker@npm:3.0.3"
   dependencies:
@@ -14077,23 +13894,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"exit@npm:^0.1.2":
-  version: 0.1.2
-  resolution: "exit@npm:0.1.2"
-  checksum: abc407f07a875c3961e4781dfcb743b58d6c93de9ab263f4f8c9d23bb6da5f9b7764fc773f86b43dd88030444d5ab8abcb611cb680fba8ca075362b77114bba3
-  languageName: node
-  linkType: hard
-
-"expect@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "expect@npm:29.7.0"
-  dependencies:
-    "@jest/expect-utils": ^29.7.0
-    jest-get-type: ^29.6.3
-    jest-matcher-utils: ^29.7.0
-    jest-message-util: ^29.7.0
-    jest-util: ^29.7.0
-  checksum: 9257f10288e149b81254a0fda8ffe8d54a7061cd61d7515779998b012579d2b8c22354b0eb901daf0145f347403da582f75f359f4810c007182ad3fb318b5c0c
+"expect-type@npm:^1.1.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 60476b4f4c0c88bf24db0735faa7d1d0c9120c21e5b78781c0fea0d4a95838f2db0c919a055aa4bb185ccbf38e37fa3000d3bb05500ceafcc7c469955c5a4f84
   languageName: node
   linkType: hard
 
@@ -14210,7 +14014,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-json-stable-stringify@npm:2.x, fast-json-stable-stringify@npm:^2.0.0, fast-json-stable-stringify@npm:^2.1.0":
+"fast-json-stable-stringify@npm:^2.0.0":
   version: 2.1.0
   resolution: "fast-json-stable-stringify@npm:2.1.0"
   checksum: b191531e36c607977e5b1c47811158733c34ccb3bfde92c44798929e9b4154884378536d26ad90dfecd32e1ffc09c545d23535ad91b3161a27ddbb8ebe0cbecb
@@ -14329,15 +14133,6 @@ __metadata:
   dependencies:
     websocket-driver: ">=0.5.1"
   checksum: d49a62caf027f871149fc2b3f3c7104dc6d62744277eb6f9f36e2d5714e847d846b9f7f0d0b7169b25a012e24a594cde11a93034b30732e4c683f20b8a5019fa
-  languageName: node
-  linkType: hard
-
-"fb-watchman@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "fb-watchman@npm:2.0.2"
-  dependencies:
-    bser: 2.1.1
-  checksum: b15a124cef28916fe07b400eb87cbc73ca082c142abf7ca8e8de6af43eca79ca7bd13eb4d4d48240b3bd3136eaac40d16e42d6edf87a8e5d1dd8070626860c78
   languageName: node
   linkType: hard
 
@@ -14491,7 +14286,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^4.0.0, find-up@npm:^4.1.0":
+"find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
   dependencies:
@@ -14712,7 +14507,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@npm:^2.3.2, fsevents@npm:~2.3.2":
+"fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
@@ -14722,7 +14517,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fsevents@patch:fsevents@^2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>":
+"fsevents@patch:fsevents@~2.3.2#~builtin<compat/fsevents>, fsevents@patch:fsevents@~2.3.3#~builtin<compat/fsevents>":
   version: 2.3.3
   resolution: "fsevents@patch:fsevents@npm%3A2.3.3#~builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
   dependencies:
@@ -14754,36 +14549,6 @@ __metadata:
   version: 1.2.3
   resolution: "functions-have-names@npm:1.2.3"
   checksum: c3f1f5ba20f4e962efb71344ce0a40722163e85bee2101ce25f88214e78182d2d2476aa85ef37950c579eb6cf6ee811c17b3101bb84004bb75655f3e33f3fdb5
-  languageName: node
-  linkType: hard
-
-"ganache@npm:^7.9.2":
-  version: 7.9.2
-  resolution: "ganache@npm:7.9.2"
-  dependencies:
-    "@trufflesuite/bigint-buffer": 1.1.10
-    "@trufflesuite/uws-js-unofficial": 20.30.0-unofficial.0
-    "@types/bn.js": ^5.1.0
-    "@types/lru-cache": 5.1.1
-    "@types/seedrandom": 3.0.1
-    abstract-level: 1.0.3
-    abstract-leveldown: 7.2.0
-    async-eventemitter: 0.2.4
-    bufferutil: 4.0.5
-    emittery: 0.10.0
-    keccak: 3.0.2
-    leveldown: 6.1.0
-    secp256k1: 4.0.3
-    utf-8-validate: 5.0.7
-  dependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  bin:
-    ganache: dist/node/cli.js
-    ganache-cli: dist/node/cli.js
-  checksum: 30af47d29e8f10e79f41f2f29e126c36c157767bdf19d8d8f101cfa9bc75eaca933c1c470557041728eef2dd7e2bd8d4715691996b5951d04f8056036cf6cfa0
   languageName: node
   linkType: hard
 
@@ -14886,17 +14651,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-package-type@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "get-package-type@npm:0.1.0"
-  checksum: bba0811116d11e56d702682ddef7c73ba3481f114590e705fc549f4d868972263896af313c57a25c076e3c0d567e11d919a64ba1b30c879be985fc9d44f96148
-  languageName: node
-  linkType: hard
-
 "get-port-please@npm:^3.1.2":
   version: 3.1.2
   resolution: "get-port-please@npm:3.1.2"
   checksum: 8e65b56459ead2f31c446d76bb8eb639c33e04e72b07a4dd5d8acc39738f12962591e90b2befecf10492844d0d11c2122c281f5204ee48692d4a8ba0ec68733a
+  languageName: node
+  linkType: hard
+
+"get-port@npm:^6.1.2":
+  version: 6.1.2
+  resolution: "get-port@npm:6.1.2"
+  checksum: e3c3d591492a11393455ef220f24c812a28f7da56ec3e4a2512d931a1f196d42850b50ac6138349a44622eda6dc3c0ccd8495cd91376d968e2d9e6f6f849e0a9
   languageName: node
   linkType: hard
 
@@ -15653,7 +15418,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"html-escaper@npm:^2.0.0, html-escaper@npm:^2.0.2":
+"html-escaper@npm:^2.0.2":
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: d2df2da3ad40ca9ee3a39c5cc6475ef67c8f83c234475f24d8e9ce0dc80a2c82df8e1d6fa78ddd1e9022a586ea1bd247a615e80a5cd9273d90111ddda7d9e974
@@ -16042,18 +15807,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"import-local@npm:^3.0.2":
-  version: 3.1.0
-  resolution: "import-local@npm:3.1.0"
-  dependencies:
-    pkg-dir: ^4.2.0
-    resolve-cwd: ^3.0.0
-  bin:
-    import-local-fixture: fixtures/cli.js
-  checksum: bfcdb63b5e3c0e245e347f3107564035b128a414c4da1172a20dc67db2504e05ede4ac2eee1252359f78b0bfd7b19ef180aec427c2fce6493ae782d73a04cddd
-  languageName: node
-  linkType: hard
-
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -16403,13 +16156,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-buffer@npm:^2.0.5":
-  version: 2.0.5
-  resolution: "is-buffer@npm:2.0.5"
-  checksum: 764c9ad8b523a9f5a32af29bdf772b08eb48c04d2ad0a7240916ac2688c983bf5f8504bf25b35e66240edeb9d9085461f9b5dae1f3d2861c6b06a65fe983de42
-  languageName: node
-  linkType: hard
-
 "is-builtin-module@npm:^3.2.0":
   version: 3.2.1
   resolution: "is-builtin-module@npm:3.2.1"
@@ -16516,13 +16262,6 @@ __metadata:
   version: 3.0.0
   resolution: "is-fullwidth-code-point@npm:3.0.0"
   checksum: 44a30c29457c7fb8f00297bce733f0a64cd22eca270f83e58c105e0d015e45c019491a4ab2faef91ab51d4738c670daff901c799f6a700e27f7314029e99e348
-  languageName: node
-  linkType: hard
-
-"is-generator-fn@npm:^2.0.0":
-  version: 2.1.0
-  resolution: "is-generator-fn@npm:2.1.0"
-  checksum: a6ad5492cf9d1746f73b6744e0c43c0020510b59d56ddcb78a91cbc173f09b5e6beff53d75c9c5a29feb618bfef2bf458e025ecf3a57ad2268e2fb2569f56215
   languageName: node
   linkType: hard
 
@@ -16931,71 +16670,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
-  version: 3.2.2
-  resolution: "istanbul-lib-coverage@npm:3.2.2"
-  checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-instrument@npm:^5.0.4":
-  version: 5.2.1
-  resolution: "istanbul-lib-instrument@npm:5.2.1"
-  dependencies:
-    "@babel/core": ^7.12.3
-    "@babel/parser": ^7.14.7
-    "@istanbuljs/schema": ^0.1.2
-    istanbul-lib-coverage: ^3.2.0
-    semver: ^6.3.0
-  checksum: bf16f1803ba5e51b28bbd49ed955a736488381e09375d830e42ddeb403855b2006f850711d95ad726f2ba3f1ae8e7366de7e51d2b9ac67dc4d80191ef7ddf272
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-instrument@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "istanbul-lib-instrument@npm:6.0.1"
-  dependencies:
-    "@babel/core": ^7.12.3
-    "@babel/parser": ^7.14.7
-    "@istanbuljs/schema": ^0.1.2
-    istanbul-lib-coverage: ^3.2.0
-    semver: ^7.5.4
-  checksum: fb23472e739cfc9b027cefcd7d551d5e7ca7ff2817ae5150fab99fe42786a7f7b56a29a2aa8309c37092e18297b8003f9c274f50ca4360949094d17fbac81472
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-report@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "istanbul-lib-report@npm:3.0.1"
-  dependencies:
-    istanbul-lib-coverage: ^3.0.0
-    make-dir: ^4.0.0
-    supports-color: ^7.1.0
-  checksum: fd17a1b879e7faf9bb1dc8f80b2a16e9f5b7b8498fe6ed580a618c34df0bfe53d2abd35bf8a0a00e628fb7405462576427c7df20bbe4148d19c14b431c974b21
-  languageName: node
-  linkType: hard
-
-"istanbul-lib-source-maps@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "istanbul-lib-source-maps@npm:4.0.1"
-  dependencies:
-    debug: ^4.1.1
-    istanbul-lib-coverage: ^3.0.0
-    source-map: ^0.6.1
-  checksum: 21ad3df45db4b81852b662b8d4161f6446cd250c1ddc70ef96a585e2e85c26ed7cd9c2a396a71533cfb981d1a645508bc9618cae431e55d01a0628e7dec62ef2
-  languageName: node
-  linkType: hard
-
-"istanbul-reports@npm:^3.1.3":
-  version: 3.1.6
-  resolution: "istanbul-reports@npm:3.1.6"
-  dependencies:
-    html-escaper: ^2.0.0
-    istanbul-lib-report: ^3.0.0
-  checksum: 44c4c0582f287f02341e9720997f9e82c071627e1e862895745d5f52ec72c9b9f38e1d12370015d2a71dcead794f34c7732aaef3fab80a24bc617a21c3d911d6
-  languageName: node
-  linkType: hard
-
 "it-all@npm:^3.0.9":
   version: 3.0.9
   resolution: "it-all@npm:3.0.9"
@@ -17124,371 +16798,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-changed-files@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-changed-files@npm:29.7.0"
-  dependencies:
-    execa: ^5.0.0
-    jest-util: ^29.7.0
-    p-limit: ^3.1.0
-  checksum: 963e203893c396c5dfc75e00a49426688efea7361b0f0e040035809cecd2d46b3c01c02be2d9e8d38b1138357d2de7719ea5b5be21f66c10f2e9685a5a73bb99
-  languageName: node
-  linkType: hard
-
-"jest-circus@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-circus@npm:29.7.0"
-  dependencies:
-    "@jest/environment": ^29.7.0
-    "@jest/expect": ^29.7.0
-    "@jest/test-result": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    chalk: ^4.0.0
-    co: ^4.6.0
-    dedent: ^1.0.0
-    is-generator-fn: ^2.0.0
-    jest-each: ^29.7.0
-    jest-matcher-utils: ^29.7.0
-    jest-message-util: ^29.7.0
-    jest-runtime: ^29.7.0
-    jest-snapshot: ^29.7.0
-    jest-util: ^29.7.0
-    p-limit: ^3.1.0
-    pretty-format: ^29.7.0
-    pure-rand: ^6.0.0
-    slash: ^3.0.0
-    stack-utils: ^2.0.3
-  checksum: 349437148924a5a109c9b8aad6d393a9591b4dac1918fc97d81b7fc515bc905af9918495055071404af1fab4e48e4b04ac3593477b1d5dcf48c4e71b527c70a7
-  languageName: node
-  linkType: hard
-
-"jest-cli@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-cli@npm:29.7.0"
-  dependencies:
-    "@jest/core": ^29.7.0
-    "@jest/test-result": ^29.7.0
-    "@jest/types": ^29.6.3
-    chalk: ^4.0.0
-    create-jest: ^29.7.0
-    exit: ^0.1.2
-    import-local: ^3.0.2
-    jest-config: ^29.7.0
-    jest-util: ^29.7.0
-    jest-validate: ^29.7.0
-    yargs: ^17.3.1
-  peerDependencies:
-    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  bin:
-    jest: bin/jest.js
-  checksum: 664901277a3f5007ea4870632ed6e7889db9da35b2434e7cb488443e6bf5513889b344b7fddf15112135495b9875892b156faeb2d7391ddb9e2a849dcb7b6c36
-  languageName: node
-  linkType: hard
-
-"jest-config@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-config@npm:29.7.0"
-  dependencies:
-    "@babel/core": ^7.11.6
-    "@jest/test-sequencer": ^29.7.0
-    "@jest/types": ^29.6.3
-    babel-jest: ^29.7.0
-    chalk: ^4.0.0
-    ci-info: ^3.2.0
-    deepmerge: ^4.2.2
-    glob: ^7.1.3
-    graceful-fs: ^4.2.9
-    jest-circus: ^29.7.0
-    jest-environment-node: ^29.7.0
-    jest-get-type: ^29.6.3
-    jest-regex-util: ^29.6.3
-    jest-resolve: ^29.7.0
-    jest-runner: ^29.7.0
-    jest-util: ^29.7.0
-    jest-validate: ^29.7.0
-    micromatch: ^4.0.4
-    parse-json: ^5.2.0
-    pretty-format: ^29.7.0
-    slash: ^3.0.0
-    strip-json-comments: ^3.1.1
-  peerDependencies:
-    "@types/node": "*"
-    ts-node: ">=9.0.0"
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    ts-node:
-      optional: true
-  checksum: 4cabf8f894c180cac80b7df1038912a3fc88f96f2622de33832f4b3314f83e22b08fb751da570c0ab2b7988f21604bdabade95e3c0c041068ac578c085cf7dff
-  languageName: node
-  linkType: hard
-
-"jest-diff@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-diff@npm:29.7.0"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^29.6.3
-    jest-get-type: ^29.6.3
-    pretty-format: ^29.7.0
-  checksum: 08e24a9dd43bfba1ef07a6374e5af138f53137b79ec3d5cc71a2303515335898888fa5409959172e1e05de966c9e714368d15e8994b0af7441f0721ee8e1bb77
-  languageName: node
-  linkType: hard
-
-"jest-docblock@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-docblock@npm:29.7.0"
-  dependencies:
-    detect-newline: ^3.0.0
-  checksum: 66390c3e9451f8d96c5da62f577a1dad701180cfa9b071c5025acab2f94d7a3efc2515cfa1654ebe707213241541ce9c5530232cdc8017c91ed64eea1bd3b192
-  languageName: node
-  linkType: hard
-
-"jest-each@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-each@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    chalk: ^4.0.0
-    jest-get-type: ^29.6.3
-    jest-util: ^29.7.0
-    pretty-format: ^29.7.0
-  checksum: e88f99f0184000fc8813f2a0aa79e29deeb63700a3b9b7928b8a418d7d93cd24933608591dbbdea732b473eb2021c72991b5cc51a17966842841c6e28e6f691c
-  languageName: node
-  linkType: hard
-
-"jest-environment-node@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-environment-node@npm:29.7.0"
-  dependencies:
-    "@jest/environment": ^29.7.0
-    "@jest/fake-timers": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    jest-mock: ^29.7.0
-    jest-util: ^29.7.0
-  checksum: 501a9966292cbe0ca3f40057a37587cb6def25e1e0c5e39ac6c650fe78d3c70a2428304341d084ac0cced5041483acef41c477abac47e9a290d5545fd2f15646
-  languageName: node
-  linkType: hard
-
-"jest-get-type@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "jest-get-type@npm:29.6.3"
-  checksum: 88ac9102d4679d768accae29f1e75f592b760b44277df288ad76ce5bf038c3f5ce3719dea8aa0f035dac30e9eb034b848ce716b9183ad7cc222d029f03e92205
-  languageName: node
-  linkType: hard
-
-"jest-haste-map@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-haste-map@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    "@types/graceful-fs": ^4.1.3
-    "@types/node": "*"
-    anymatch: ^3.0.3
-    fb-watchman: ^2.0.0
-    fsevents: ^2.3.2
-    graceful-fs: ^4.2.9
-    jest-regex-util: ^29.6.3
-    jest-util: ^29.7.0
-    jest-worker: ^29.7.0
-    micromatch: ^4.0.4
-    walker: ^1.0.8
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  checksum: c2c8f2d3e792a963940fbdfa563ce14ef9e14d4d86da645b96d3cd346b8d35c5ce0b992ee08593939b5f718cf0a1f5a90011a056548a1dbf58397d4356786f01
-  languageName: node
-  linkType: hard
-
-"jest-leak-detector@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-leak-detector@npm:29.7.0"
-  dependencies:
-    jest-get-type: ^29.6.3
-    pretty-format: ^29.7.0
-  checksum: e3950e3ddd71e1d0c22924c51a300a1c2db6cf69ec1e51f95ccf424bcc070f78664813bef7aed4b16b96dfbdeea53fe358f8aeaaea84346ae15c3735758f1605
-  languageName: node
-  linkType: hard
-
-"jest-matcher-utils@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-matcher-utils@npm:29.7.0"
-  dependencies:
-    chalk: ^4.0.0
-    jest-diff: ^29.7.0
-    jest-get-type: ^29.6.3
-    pretty-format: ^29.7.0
-  checksum: d7259e5f995d915e8a37a8fd494cb7d6af24cd2a287b200f831717ba0d015190375f9f5dc35393b8ba2aae9b2ebd60984635269c7f8cff7d85b077543b7744cd
-  languageName: node
-  linkType: hard
-
-"jest-message-util@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-message-util@npm:29.7.0"
-  dependencies:
-    "@babel/code-frame": ^7.12.13
-    "@jest/types": ^29.6.3
-    "@types/stack-utils": ^2.0.0
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    micromatch: ^4.0.4
-    pretty-format: ^29.7.0
-    slash: ^3.0.0
-    stack-utils: ^2.0.3
-  checksum: a9d025b1c6726a2ff17d54cc694de088b0489456c69106be6b615db7a51b7beb66788bea7a59991a019d924fbf20f67d085a445aedb9a4d6760363f4d7d09930
-  languageName: node
-  linkType: hard
-
-"jest-mock@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-mock@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    jest-util: ^29.7.0
-  checksum: 81ba9b68689a60be1482212878973700347cb72833c5e5af09895882b9eb5c4e02843a1bbdf23f94c52d42708bab53a30c45a3482952c9eec173d1eaac5b86c5
-  languageName: node
-  linkType: hard
-
-"jest-pnp-resolver@npm:^1.2.2":
-  version: 1.2.3
-  resolution: "jest-pnp-resolver@npm:1.2.3"
-  peerDependencies:
-    jest-resolve: "*"
-  peerDependenciesMeta:
-    jest-resolve:
-      optional: true
-  checksum: db1a8ab2cb97ca19c01b1cfa9a9c8c69a143fde833c14df1fab0766f411b1148ff0df878adea09007ac6a2085ec116ba9a996a6ad104b1e58c20adbf88eed9b2
-  languageName: node
-  linkType: hard
-
-"jest-regex-util@npm:^29.6.3":
-  version: 29.6.3
-  resolution: "jest-regex-util@npm:29.6.3"
-  checksum: 0518beeb9bf1228261695e54f0feaad3606df26a19764bc19541e0fc6e2a3737191904607fb72f3f2ce85d9c16b28df79b7b1ec9443aa08c3ef0e9efda6f8f2a
-  languageName: node
-  linkType: hard
-
-"jest-resolve-dependencies@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-resolve-dependencies@npm:29.7.0"
-  dependencies:
-    jest-regex-util: ^29.6.3
-    jest-snapshot: ^29.7.0
-  checksum: aeb75d8150aaae60ca2bb345a0d198f23496494677cd6aefa26fc005faf354061f073982175daaf32b4b9d86b26ca928586344516e3e6969aa614cb13b883984
-  languageName: node
-  linkType: hard
-
-"jest-resolve@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-resolve@npm:29.7.0"
-  dependencies:
-    chalk: ^4.0.0
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^29.7.0
-    jest-pnp-resolver: ^1.2.2
-    jest-util: ^29.7.0
-    jest-validate: ^29.7.0
-    resolve: ^1.20.0
-    resolve.exports: ^2.0.0
-    slash: ^3.0.0
-  checksum: 0ca218e10731aa17920526ec39deaec59ab9b966237905ffc4545444481112cd422f01581230eceb7e82d86f44a543d520a71391ec66e1b4ef1a578bd5c73487
-  languageName: node
-  linkType: hard
-
-"jest-runner@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-runner@npm:29.7.0"
-  dependencies:
-    "@jest/console": ^29.7.0
-    "@jest/environment": ^29.7.0
-    "@jest/test-result": ^29.7.0
-    "@jest/transform": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    chalk: ^4.0.0
-    emittery: ^0.13.1
-    graceful-fs: ^4.2.9
-    jest-docblock: ^29.7.0
-    jest-environment-node: ^29.7.0
-    jest-haste-map: ^29.7.0
-    jest-leak-detector: ^29.7.0
-    jest-message-util: ^29.7.0
-    jest-resolve: ^29.7.0
-    jest-runtime: ^29.7.0
-    jest-util: ^29.7.0
-    jest-watcher: ^29.7.0
-    jest-worker: ^29.7.0
-    p-limit: ^3.1.0
-    source-map-support: 0.5.13
-  checksum: f0405778ea64812bf9b5c50b598850d94ccf95d7ba21f090c64827b41decd680ee19fcbb494007cdd7f5d0d8906bfc9eceddd8fa583e753e736ecd462d4682fb
-  languageName: node
-  linkType: hard
-
-"jest-runtime@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-runtime@npm:29.7.0"
-  dependencies:
-    "@jest/environment": ^29.7.0
-    "@jest/fake-timers": ^29.7.0
-    "@jest/globals": ^29.7.0
-    "@jest/source-map": ^29.6.3
-    "@jest/test-result": ^29.7.0
-    "@jest/transform": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    chalk: ^4.0.0
-    cjs-module-lexer: ^1.0.0
-    collect-v8-coverage: ^1.0.0
-    glob: ^7.1.3
-    graceful-fs: ^4.2.9
-    jest-haste-map: ^29.7.0
-    jest-message-util: ^29.7.0
-    jest-mock: ^29.7.0
-    jest-regex-util: ^29.6.3
-    jest-resolve: ^29.7.0
-    jest-snapshot: ^29.7.0
-    jest-util: ^29.7.0
-    slash: ^3.0.0
-    strip-bom: ^4.0.0
-  checksum: d19f113d013e80691e07047f68e1e3448ef024ff2c6b586ce4f90cd7d4c62a2cd1d460110491019719f3c59bfebe16f0e201ed005ef9f80e2cf798c374eed54e
-  languageName: node
-  linkType: hard
-
-"jest-snapshot@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-snapshot@npm:29.7.0"
-  dependencies:
-    "@babel/core": ^7.11.6
-    "@babel/generator": ^7.7.2
-    "@babel/plugin-syntax-jsx": ^7.7.2
-    "@babel/plugin-syntax-typescript": ^7.7.2
-    "@babel/types": ^7.3.3
-    "@jest/expect-utils": ^29.7.0
-    "@jest/transform": ^29.7.0
-    "@jest/types": ^29.6.3
-    babel-preset-current-node-syntax: ^1.0.0
-    chalk: ^4.0.0
-    expect: ^29.7.0
-    graceful-fs: ^4.2.9
-    jest-diff: ^29.7.0
-    jest-get-type: ^29.6.3
-    jest-matcher-utils: ^29.7.0
-    jest-message-util: ^29.7.0
-    jest-util: ^29.7.0
-    natural-compare: ^1.4.0
-    pretty-format: ^29.7.0
-    semver: ^7.5.3
-  checksum: 86821c3ad0b6899521ce75ee1ae7b01b17e6dfeff9166f2cf17f012e0c5d8c798f30f9e4f8f7f5bed01ea7b55a6bc159f5eda778311162cbfa48785447c237ad
-  languageName: node
-  linkType: hard
-
-"jest-util@npm:^29.0.0, jest-util@npm:^29.7.0":
+"jest-util@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-util@npm:29.7.0"
   dependencies:
@@ -17499,36 +16809,6 @@ __metadata:
     graceful-fs: ^4.2.9
     picomatch: ^2.2.3
   checksum: 042ab4980f4ccd4d50226e01e5c7376a8556b472442ca6091a8f102488c0f22e6e8b89ea874111d2328a2080083bf3225c86f3788c52af0bd0345a00eb57a3ca
-  languageName: node
-  linkType: hard
-
-"jest-validate@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-validate@npm:29.7.0"
-  dependencies:
-    "@jest/types": ^29.6.3
-    camelcase: ^6.2.0
-    chalk: ^4.0.0
-    jest-get-type: ^29.6.3
-    leven: ^3.1.0
-    pretty-format: ^29.7.0
-  checksum: 191fcdc980f8a0de4dbdd879fa276435d00eb157a48683af7b3b1b98b0f7d9de7ffe12689b617779097ff1ed77601b9f7126b0871bba4f776e222c40f62e9dae
-  languageName: node
-  linkType: hard
-
-"jest-watcher@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest-watcher@npm:29.7.0"
-  dependencies:
-    "@jest/test-result": ^29.7.0
-    "@jest/types": ^29.6.3
-    "@types/node": "*"
-    ansi-escapes: ^4.2.1
-    chalk: ^4.0.0
-    emittery: ^0.13.1
-    jest-util: ^29.7.0
-    string-length: ^4.0.1
-  checksum: 67e6e7fe695416deff96b93a14a561a6db69389a0667e9489f24485bb85e5b54e12f3b2ba511ec0b777eca1e727235b073e3ebcdd473d68888650489f88df92f
   languageName: node
   linkType: hard
 
@@ -17543,7 +16823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-worker@npm:^29.4.3, jest-worker@npm:^29.7.0":
+"jest-worker@npm:^29.4.3":
   version: 29.7.0
   resolution: "jest-worker@npm:29.7.0"
   dependencies:
@@ -17552,25 +16832,6 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 30fff60af49675273644d408b650fc2eb4b5dcafc5a0a455f238322a8f9d8a98d847baca9d51ff197b6747f54c7901daa2287799230b856a0f48287d131f8c13
-  languageName: node
-  linkType: hard
-
-"jest@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "jest@npm:29.7.0"
-  dependencies:
-    "@jest/core": ^29.7.0
-    "@jest/types": ^29.6.3
-    import-local: ^3.0.2
-    jest-cli: ^29.7.0
-  peerDependencies:
-    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  bin:
-    jest: bin/jest.js
-  checksum: 17ca8d67504a7dbb1998cf3c3077ec9031ba3eb512da8d71cb91bcabb2b8995c4e4b292b740cb9bf1cbff5ce3e110b3f7c777b0cefb6f41ab05445f248d0ee0b
   languageName: node
   linkType: hard
 
@@ -17835,18 +17096,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keccak@npm:3.0.2":
-  version: 3.0.2
-  resolution: "keccak@npm:3.0.2"
-  dependencies:
-    node-addon-api: ^2.0.0
-    node-gyp: latest
-    node-gyp-build: ^4.2.0
-    readable-stream: ^3.6.0
-  checksum: 39a7d6128b8ee4cb7dcd186fc7e20c6087cc39f573a0f81b147c323f688f1f7c2b34f62c4ae189fe9b81c6730b2d1228d8a399cdc1f3d8a4c8f030cdc4f20272
-  languageName: node
-  linkType: hard
-
 "keccak@npm:^3.0.3":
   version: 3.0.4
   resolution: "keccak@npm:3.0.4"
@@ -17962,51 +17211,6 @@ __metadata:
   version: 2.0.1
   resolution: "layout-base@npm:2.0.1"
   checksum: ef93baf044f67c3680f4f3a6d628bf4c7faba0f70f3e0abb16e4811bed087045208560347ca749e123d169cbf872505ad84e11fb21b0be925997227e042c7f43
-  languageName: node
-  linkType: hard
-
-"level-concat-iterator@npm:^3.0.0":
-  version: 3.1.0
-  resolution: "level-concat-iterator@npm:3.1.0"
-  dependencies:
-    catering: ^2.1.0
-  checksum: a15bc4c5fbbb30c1efa7fad06b72feaac84d90990b356b461593c198a833336f31f6daff8f40c3908fabd14cfd8856d1c5ecae9e1cb0575037b65fa607e760e9
-  languageName: node
-  linkType: hard
-
-"level-supports@npm:^2.0.1":
-  version: 2.1.0
-  resolution: "level-supports@npm:2.1.0"
-  checksum: f7b16aea7ddd13326ee4fbc2c1099bcaf8a74dc95346af9ebedea4e02518c6f7a438e829b79b7890d67489b59f615a9428369a0a065021797aa7cb6b6bd84d75
-  languageName: node
-  linkType: hard
-
-"level-supports@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "level-supports@npm:4.0.1"
-  checksum: d4552b42bb8cdeada07b0f6356c7a90fefe76279147331f291aceae26e3e56d5f927b09ce921647c0230bfe03ddfbdcef332be921e5c2194421ae2bfa3cf6368
-  languageName: node
-  linkType: hard
-
-"level-transcoder@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "level-transcoder@npm:1.0.1"
-  dependencies:
-    buffer: ^6.0.3
-    module-error: ^1.0.1
-  checksum: 304f08d802faf3491a533b6d87ad8be3cabfd27f2713bbe9d4c633bf50fcb9460eab5a6776bf015e101ead7ba1c1853e05e7f341112f17a9d0cb37ee5a421a25
-  languageName: node
-  linkType: hard
-
-"leveldown@npm:6.1.0":
-  version: 6.1.0
-  resolution: "leveldown@npm:6.1.0"
-  dependencies:
-    abstract-leveldown: ^7.2.0
-    napi-macros: ~2.0.0
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: e984b61e9fbe057cfd5c81ac0afe5d7e35d695ff130a95991e0ecb66390e4c4ff6aa3980a65b6c53edaba80527a47790bb26e3cfbd52a054957b3546d9941fe4
   languageName: node
   linkType: hard
 
@@ -18500,7 +17704,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash.memoize@npm:4.x, lodash.memoize@npm:^4.1.2":
+"lodash.memoize@npm:^4.1.2":
   version: 4.1.2
   resolution: "lodash.memoize@npm:4.1.2"
   checksum: 9ff3942feeccffa4f1fafa88d32f0d24fdc62fd15ded5a74a5f950ff5f0c6f61916157246744c620173dddf38d37095a92327d5fd3861e2063e736a5c207d089
@@ -18556,7 +17760,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.14, lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
+"lodash@npm:^4.17.15, lodash@npm:^4.17.20, lodash@npm:^4.17.21":
   version: 4.17.23
   resolution: "lodash@npm:4.17.23"
   checksum: 7daad39758a72872e94651630fbb54ba76868f904211089721a64516ce865506a759d9ad3d8ff22a2a49a50a09db5d27c36f22762d21766e47e3ba918d6d7bab
@@ -18578,6 +17782,13 @@ __metadata:
   bin:
     loose-envify: cli.js
   checksum: 6517e24e0cad87ec9888f500c5b5947032cdfe6ef65e1c1936a0c48a524b81e65542c9c3edc91c97d5bddc806ee2a985dbc79be89215d613b1de5db6d1cfe6f4
+  languageName: node
+  linkType: hard
+
+"loupe@npm:^3.1.0, loupe@npm:^3.1.2":
+  version: 3.2.1
+  resolution: "loupe@npm:3.2.1"
+  checksum: 3ce9ecc5b2c56ffc073bf065ad3a4644cccce3eac81e61a8732e9c8ebfe05513ed478592d25f9dba24cfe82766913be045ab384c04711c7c6447deaf800ad94c
   languageName: node
   linkType: hard
 
@@ -18629,6 +17840,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"magic-string@npm:^0.30.12":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": ^1.5.5
+  checksum: 4ff76a4e8d439431cf49f039658751ed351962d044e5955adc257489569bd676019c906b631f86319217689d04815d7d064ee3ff08ab82ae65b7655a7e82a414
+  languageName: node
+  linkType: hard
+
 "main-event@npm:^1.0.1":
   version: 1.0.1
   resolution: "main-event@npm:1.0.1"
@@ -18636,16 +17856,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"make-dir@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "make-dir@npm:4.0.0"
-  dependencies:
-    semver: ^7.5.3
-  checksum: bf0731a2dd3aab4db6f3de1585cea0b746bb73eb5a02e3d8d72757e376e64e6ada190b1eddcde5b2f24a81b688a9897efd5018737d05e02e2a671dda9cff8a8a
-  languageName: node
-  linkType: hard
-
-"make-error@npm:1.x, make-error@npm:^1.1.1":
+"make-error@npm:^1.1.1":
   version: 1.3.6
   resolution: "make-error@npm:1.3.6"
   checksum: b86e5e0e25f7f777b77fabd8e2cbf15737972869d852a22b7e73c17623928fccb826d8e46b9951501d3f20e51ad74ba8c59ed584f610526a48f8ccf88aaec402
@@ -18715,15 +17926,6 @@ __metadata:
     promise-retry: ^2.0.1
     ssri: ^10.0.0
   checksum: 7c7a6d381ce919dd83af398b66459a10e2fe8f4504f340d1d090d3fa3d1b0c93750220e1d898114c64467223504bd258612ba83efbc16f31b075cd56de24b4af
-  languageName: node
-  linkType: hard
-
-"makeerror@npm:1.0.12":
-  version: 1.0.12
-  resolution: "makeerror@npm:1.0.12"
-  dependencies:
-    tmpl: 1.0.5
-  checksum: b38a025a12c8146d6eeea5a7f2bf27d51d8ad6064da8ca9405fcf7bf9b54acd43e3b30ddd7abb9b1bfa4ddb266019133313482570ddb207de568f71ecfcf6060
   languageName: node
   linkType: hard
 
@@ -19716,7 +18918,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"micromatch@npm:^4.0.2, micromatch@npm:^4.0.4, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
+"micromatch@npm:^4.0.2, micromatch@npm:^4.0.5, micromatch@npm:^4.0.8":
   version: 4.0.8
   resolution: "micromatch@npm:4.0.8"
   dependencies:
@@ -19862,7 +19064,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:3.1.2, minimatch@npm:^3.0.4, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
+"minimatch@npm:3.1.2, minimatch@npm:^3.0.5, minimatch@npm:^3.1.1, minimatch@npm:^3.1.2":
   version: 3.1.2
   resolution: "minimatch@npm:3.1.2"
   dependencies:
@@ -20074,13 +19276,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"module-error@npm:^1.0.1":
-  version: 1.0.2
-  resolution: "module-error@npm:1.0.2"
-  checksum: 5d653e35bd55b3e95f8aee2cdac108082ea892e71b8f651be92cde43e4ee86abee4fa8bd7fc3fe5e68b63926d42f63c54cd17b87a560c31f18739295575a3962
-  languageName: node
-  linkType: hard
-
 "motion@npm:10.16.2":
   version: 10.16.2
   resolution: "motion@npm:10.16.2"
@@ -20183,13 +19378,6 @@ __metadata:
   bin:
     nanoid: bin/nanoid.cjs
   checksum: dfe0adbc0c77e9655b550c333075f51bb28cfc7568afbf3237249904f9c86c9aaaed1f113f0fddddba75673ee31c758c30c43d4414f014a52a7a626efc5958c9
-  languageName: node
-  linkType: hard
-
-"napi-macros@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "napi-macros@npm:2.0.0"
-  checksum: 30384819386977c1f82034757014163fa60ab3c5a538094f778d38788bebb52534966279956f796a92ea771c7f8ae072b975df65de910d051ffbdc927f62320c
   languageName: node
   linkType: hard
 
@@ -20386,17 +19574,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-gyp-build@npm:4.4.0":
-  version: 4.4.0
-  resolution: "node-gyp-build@npm:4.4.0"
-  bin:
-    node-gyp-build: bin.js
-    node-gyp-build-optional: optional.js
-    node-gyp-build-test: build-test.js
-  checksum: 972a059f960253d254e0b23ce10f54c8982236fc0edcab85166d0b7f87443b2ce98391c877cfb2f6eeafcf03c538c5f4dd3e0bfff03828eb48634f58f4c64343
-  languageName: node
-  linkType: hard
-
 "node-gyp-build@npm:^4.2.0, node-gyp-build@npm:^4.3.0":
   version: 4.8.0
   resolution: "node-gyp-build@npm:4.8.0"
@@ -20446,13 +19623,6 @@ __metadata:
   bin:
     node-gyp: bin/node-gyp.js
   checksum: 60a74e66d364903ce02049966303a57f898521d139860ac82744a5fdd9f7b7b3b61f75f284f3bfe6e6add3b8f1871ce305a1d41f775c7482de837b50c792223f
-  languageName: node
-  linkType: hard
-
-"node-int64@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "node-int64@npm:0.4.0"
-  checksum: d0b30b1ee6d961851c60d5eaa745d30b5c95d94bc0e74b81e5292f7c42a49e3af87f1eb9e89f59456f80645d679202537de751b7d72e9e40ceea40c5e449057e
   languageName: node
   linkType: hard
 
@@ -21162,7 +20332,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"p-limit@npm:^3.0.2, p-limit@npm:^3.1.0":
+"p-limit@npm:^3.0.2":
   version: 3.1.0
   resolution: "p-limit@npm:3.1.0"
   dependencies:
@@ -21602,6 +20772,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathval@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "pathval@npm:2.0.1"
+  checksum: 280e71cfd86bb5d7ff371fe2752997e5fa82901fcb209abf19d4457b7814f1b4a17845dfb17bd28a596ccdb0ecea178720ce23dacfa9c841f37804b700647810
+  languageName: node
+  linkType: hard
+
 "performance-now@npm:^2.1.0":
   version: 2.1.0
   resolution: "performance-now@npm:2.1.0"
@@ -21761,13 +20938,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pirates@npm:^4.0.4":
-  version: 4.0.6
-  resolution: "pirates@npm:4.0.6"
-  checksum: 46a65fefaf19c6f57460388a5af9ab81e3d7fd0e7bc44ca59d753cb5c4d0df97c6c6e583674869762101836d68675f027d60f841c105d72734df9dfca97cbcc6
-  languageName: node
-  linkType: hard
-
 "pkg-conf@npm:^2.1.0":
   version: 2.1.0
   resolution: "pkg-conf@npm:2.1.0"
@@ -21775,15 +20945,6 @@ __metadata:
     find-up: ^2.0.0
     load-json-file: ^4.0.0
   checksum: b50775157262abd1bfb4d3d948f3fc6c009d10266c6507d4de296af4e2cbb6d2738310784432185886d83144466fbb286b6e8ff0bc23dc5ee7d81810dc6c4788
-  languageName: node
-  linkType: hard
-
-"pkg-dir@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "pkg-dir@npm:4.2.0"
-  dependencies:
-    find-up: ^4.0.0
-  checksum: 9863e3f35132bf99ae1636d31ff1e1e3501251d480336edb1c211133c8d58906bed80f154a1d723652df1fda91e01c7442c2eeaf9dc83157c7ae89087e43c8d6
   languageName: node
   linkType: hard
 
@@ -22739,17 +21900,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^29.7.0":
-  version: 29.7.0
-  resolution: "pretty-format@npm:29.7.0"
-  dependencies:
-    "@jest/schemas": ^29.6.3
-    ansi-styles: ^5.0.0
-    react-is: ^18.0.0
-  checksum: 032c1602383e71e9c0c02a01bbd25d6759d60e9c7cf21937dde8357aa753da348fcec5def5d1002c9678a8524d5fe099ad98861286550ef44de8808cc61e43b6
-  languageName: node
-  linkType: hard
-
 "pretty-time@npm:^1.1.0":
   version: 1.1.0
   resolution: "pretty-time@npm:1.1.0"
@@ -22888,7 +22038,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prompts@npm:^2.0.1, prompts@npm:^2.4.2":
+"prompts@npm:^2.4.2":
   version: 2.4.2
   resolution: "prompts@npm:2.4.2"
   dependencies:
@@ -23014,13 +22164,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^6.0.0":
-  version: 6.0.4
-  resolution: "pure-rand@npm:6.0.4"
-  checksum: e1c4e69f8bf7303e5252756d67c3c7551385cd34d94a1f511fe099727ccbab74c898c03a06d4c4a24a89b51858781057b83ebbfe740d984240cdc04fead36068
-  languageName: node
-  linkType: hard
-
 "pvtsutils@npm:^1.3.6":
   version: 1.3.6
   resolution: "pvtsutils@npm:1.3.6"
@@ -23088,7 +22231,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"queue-microtask@npm:^1.2.2, queue-microtask@npm:^1.2.3":
+"queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
   checksum: b676f8c040cdc5b12723ad2f91414d267605b26419d5c821ff03befa817ddd10e238d22b25d604920340fd73efd8ba795465a0377c4adf45a4a41e4234e42dc4
@@ -23267,13 +22410,6 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
-  languageName: node
-  linkType: hard
-
-"react-is@npm:^18.0.0":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: e20fe84c86ff172fc8d898251b7cc2c43645d108bf96d0b8edf39b98f9a2cae97b40520ee7ed8ee0085ccc94736c4886294456033304151c3f94978cec03df21
   languageName: node
   linkType: hard
 
@@ -23942,15 +23078,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve-cwd@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-cwd@npm:3.0.0"
-  dependencies:
-    resolve-from: ^5.0.0
-  checksum: 546e0816012d65778e580ad62b29e975a642989108d9a3c5beabfb2304192fa3c9f9146fbdfe213563c6ff51975ae41bac1d3c6e047dd9572c94863a057b4d81
-  languageName: node
-  linkType: hard
-
 "resolve-from@npm:5.0.0, resolve-from@npm:^5.0.0":
   version: 5.0.0
   resolution: "resolve-from@npm:5.0.0"
@@ -23988,14 +23115,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve.exports@npm:^2.0.0":
-  version: 2.0.2
-  resolution: "resolve.exports@npm:2.0.2"
-  checksum: 1c7778ca1b86a94f8ab4055d196c7d87d1874b96df4d7c3e67bbf793140f0717fd506dcafd62785b079cd6086b9264424ad634fb904409764c3509c3df1653f2
-  languageName: node
-  linkType: hard
-
-"resolve@npm:^1.10.0, resolve@npm:^1.20.0, resolve@npm:^1.22.10, resolve@npm:^1.22.4":
+"resolve@npm:^1.10.0, resolve@npm:^1.22.10, resolve@npm:^1.22.4":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -24021,7 +23141,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.20.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.10#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
+"resolve@patch:resolve@^1.10.0#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.10#~builtin<compat/resolve>, resolve@patch:resolve@^1.22.4#~builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#~builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -24138,6 +23258,96 @@ __metadata:
   version: 3.0.2
   resolution: "robust-predicates@npm:3.0.2"
   checksum: 36854c1321548ceca96d36ad9d6e0a5a512986029ec6929ad6ed3ec1612c22cc8b46cc72d2c5674af42e8074a119d793f6f0ea3a5b51373e3ab926c64b172d7a
+  languageName: node
+  linkType: hard
+
+"rollup@npm:^4.20.0":
+  version: 4.60.0
+  resolution: "rollup@npm:4.60.0"
+  dependencies:
+    "@rollup/rollup-android-arm-eabi": 4.60.0
+    "@rollup/rollup-android-arm64": 4.60.0
+    "@rollup/rollup-darwin-arm64": 4.60.0
+    "@rollup/rollup-darwin-x64": 4.60.0
+    "@rollup/rollup-freebsd-arm64": 4.60.0
+    "@rollup/rollup-freebsd-x64": 4.60.0
+    "@rollup/rollup-linux-arm-gnueabihf": 4.60.0
+    "@rollup/rollup-linux-arm-musleabihf": 4.60.0
+    "@rollup/rollup-linux-arm64-gnu": 4.60.0
+    "@rollup/rollup-linux-arm64-musl": 4.60.0
+    "@rollup/rollup-linux-loong64-gnu": 4.60.0
+    "@rollup/rollup-linux-loong64-musl": 4.60.0
+    "@rollup/rollup-linux-ppc64-gnu": 4.60.0
+    "@rollup/rollup-linux-ppc64-musl": 4.60.0
+    "@rollup/rollup-linux-riscv64-gnu": 4.60.0
+    "@rollup/rollup-linux-riscv64-musl": 4.60.0
+    "@rollup/rollup-linux-s390x-gnu": 4.60.0
+    "@rollup/rollup-linux-x64-gnu": 4.60.0
+    "@rollup/rollup-linux-x64-musl": 4.60.0
+    "@rollup/rollup-openbsd-x64": 4.60.0
+    "@rollup/rollup-openharmony-arm64": 4.60.0
+    "@rollup/rollup-win32-arm64-msvc": 4.60.0
+    "@rollup/rollup-win32-ia32-msvc": 4.60.0
+    "@rollup/rollup-win32-x64-gnu": 4.60.0
+    "@rollup/rollup-win32-x64-msvc": 4.60.0
+    "@types/estree": 1.0.8
+    fsevents: ~2.3.2
+  dependenciesMeta:
+    "@rollup/rollup-android-arm-eabi":
+      optional: true
+    "@rollup/rollup-android-arm64":
+      optional: true
+    "@rollup/rollup-darwin-arm64":
+      optional: true
+    "@rollup/rollup-darwin-x64":
+      optional: true
+    "@rollup/rollup-freebsd-arm64":
+      optional: true
+    "@rollup/rollup-freebsd-x64":
+      optional: true
+    "@rollup/rollup-linux-arm-gnueabihf":
+      optional: true
+    "@rollup/rollup-linux-arm-musleabihf":
+      optional: true
+    "@rollup/rollup-linux-arm64-gnu":
+      optional: true
+    "@rollup/rollup-linux-arm64-musl":
+      optional: true
+    "@rollup/rollup-linux-loong64-gnu":
+      optional: true
+    "@rollup/rollup-linux-loong64-musl":
+      optional: true
+    "@rollup/rollup-linux-ppc64-gnu":
+      optional: true
+    "@rollup/rollup-linux-ppc64-musl":
+      optional: true
+    "@rollup/rollup-linux-riscv64-gnu":
+      optional: true
+    "@rollup/rollup-linux-riscv64-musl":
+      optional: true
+    "@rollup/rollup-linux-s390x-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-gnu":
+      optional: true
+    "@rollup/rollup-linux-x64-musl":
+      optional: true
+    "@rollup/rollup-openbsd-x64":
+      optional: true
+    "@rollup/rollup-openharmony-arm64":
+      optional: true
+    "@rollup/rollup-win32-arm64-msvc":
+      optional: true
+    "@rollup/rollup-win32-ia32-msvc":
+      optional: true
+    "@rollup/rollup-win32-x64-gnu":
+      optional: true
+    "@rollup/rollup-win32-x64-msvc":
+      optional: true
+    fsevents:
+      optional: true
+  bin:
+    rollup: dist/bin/rollup
+  checksum: 2b02a86ada3ddaa19786f23fd5176b5ff41faebcd7e8f5131e30abd5713a0cbd1dbce9b101bd8d2aaff0d5e8a381d18e319b792576ea7596c9e8d75ae681e26e
   languageName: node
   linkType: hard
 
@@ -24328,18 +23538,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"secp256k1@npm:4.0.3":
-  version: 4.0.3
-  resolution: "secp256k1@npm:4.0.3"
-  dependencies:
-    elliptic: ^6.5.4
-    node-addon-api: ^2.0.0
-    node-gyp: latest
-    node-gyp-build: ^4.2.0
-  checksum: 21e219adc0024fbd75021001358780a3cc6ac21273c3fcaef46943af73969729709b03f1df7c012a0baab0830fb9a06ccc6b42f8d50050c665cb98078eab477b
-  languageName: node
-  linkType: hard
-
 "section-matter@npm:^1.0.0":
   version: 1.0.0
   resolution: "section-matter@npm:1.0.0"
@@ -24448,7 +23646,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^6.3.0, semver@npm:^6.3.1":
+"semver@npm:^6.3.1":
   version: 6.3.1
   resolution: "semver@npm:6.3.1"
   bin:
@@ -24698,6 +23896,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 8aa5a98640ca09fe00d74416eca97551b3e42991614a3d1b824b115fc1401543650914f651ab1311518177e4d297e80b953f4cd4cd7ea1eabe824e8f2091de01
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^3.0.2, signal-exit@npm:^3.0.3, signal-exit@npm:^3.0.7":
   version: 3.0.7
   resolution: "signal-exit@npm:3.0.7"
@@ -24943,16 +24148,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-support@npm:0.5.13":
-  version: 0.5.13
-  resolution: "source-map-support@npm:0.5.13"
-  dependencies:
-    buffer-from: ^1.0.0
-    source-map: ^0.6.0
-  checksum: 933550047b6c1a2328599a21d8b7666507427c0f5ef5eaadd56b5da0fd9505e239053c66fe181bf1df469a3b7af9d775778eee283cbb7ae16b902ddc09e93a97
-  languageName: node
-  linkType: hard
-
 "source-map-support@npm:~0.5.20":
   version: 0.5.21
   resolution: "source-map-support@npm:0.5.21"
@@ -25146,12 +24341,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"stack-utils@npm:^2.0.3":
-  version: 2.0.6
-  resolution: "stack-utils@npm:2.0.6"
-  dependencies:
-    escape-string-regexp: ^2.0.0
-  checksum: 052bf4d25bbf5f78e06c1d5e67de2e088b06871fa04107ca8d3f0e9d9263326e2942c8bedee3545795fc77d787d443a538345eef74db2f8e35db3558c6f91ff7
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 2d4dc4e64e2db796de4a3c856d5943daccdfa3dd092e452a1ce059c81e9a9c29e0b9badba91b43ef0d5ff5c04ee62feb3bcc559a804e16faf447bac2d883aa99
   languageName: node
   linkType: hard
 
@@ -25190,6 +24383,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"std-env@npm:^3.8.0":
+  version: 3.10.0
+  resolution: "std-env@npm:3.10.0"
+  checksum: 51d641b36b0fae494a546fb8446d39a837957fbf902c765c62bd12af8e50682d141c4087ca032f1192fa90330c4f6ff23fd6c9795324efacd1684e814471e0e0
+  languageName: node
+  linkType: hard
+
 "stream-buffers@npm:^3.0.2":
   version: 3.0.2
   resolution: "stream-buffers@npm:3.0.2"
@@ -25225,16 +24425,6 @@ __metadata:
   version: 2.0.0
   resolution: "strict-uri-encode@npm:2.0.0"
   checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
-  languageName: node
-  linkType: hard
-
-"string-length@npm:^4.0.1":
-  version: 4.0.2
-  resolution: "string-length@npm:4.0.2"
-  dependencies:
-    char-regex: ^1.0.2
-    strip-ansi: ^6.0.0
-  checksum: ce85533ef5113fcb7e522bcf9e62cb33871aa99b3729cec5595f4447f660b0cefd542ca6df4150c97a677d58b0cb727a3fe09ac1de94071d05526c73579bf505
   languageName: node
   linkType: hard
 
@@ -25378,13 +24568,6 @@ __metadata:
   version: 3.0.0
   resolution: "strip-bom@npm:3.0.0"
   checksum: 8d50ff27b7ebe5ecc78f1fe1e00fcdff7af014e73cf724b46fb81ef889eeb1015fc5184b64e81a2efe002180f3ba431bdd77e300da5c6685d702780fbf0c8d5b
-  languageName: node
-  linkType: hard
-
-"strip-bom@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "strip-bom@npm:4.0.0"
-  checksum: 9dbcfbaf503c57c06af15fe2c8176fb1bf3af5ff65003851a102749f875a6dbe0ab3b30115eccf6e805e9d756830d3e40ec508b62b3f1ddf3761a20ebe29d3f3
   languageName: node
   linkType: hard
 
@@ -25728,17 +24911,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"test-exclude@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "test-exclude@npm:6.0.0"
-  dependencies:
-    "@istanbuljs/schema": ^0.1.2
-    glob: ^7.1.4
-    minimatch: ^3.0.4
-  checksum: 3b34a3d77165a2cb82b34014b3aba93b1c4637a5011807557dc2f3da826c59975a5ccad765721c4648b39817e3472789f9b0fa98fc854c5c1c7a1e632aacdc28
-  languageName: node
-  linkType: hard
-
 "text-extensions@npm:^1.0.0":
   version: 1.9.0
   resolution: "text-extensions@npm:1.9.0"
@@ -25850,6 +25022,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 1ab00d7dfe0d1f127cbf00822bacd9024f7a50a3ecd1f354a8168e0b7d2b53a639a24414e707c27879d1adc0f5153141d51d76ebd7b4d37fe245e742e5d91fe8
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^0.3.1":
+  version: 0.3.2
+  resolution: "tinyexec@npm:0.3.2"
+  checksum: bd491923020610bdeadb0d8cf5d70e7cbad5a3201620fd01048c9bf3b31ffaa75c33254e1540e13b993ce4e8187852b0b5a93057bb598e7a57afa2ca2048a35c
+  languageName: node
+  linkType: hard
+
 "tinyexec@npm:^1.0.1":
   version: 1.0.1
   resolution: "tinyexec@npm:1.0.1"
@@ -25857,17 +25043,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinypool@npm:^1.0.2":
+"tinypool@npm:^1.0.1, tinypool@npm:^1.0.2":
   version: 1.1.1
   resolution: "tinypool@npm:1.1.1"
   checksum: 0258abe108df8be395a2cbdc8b4390c94908850250530f7bea83a129fa33d49a8c93246f76bf81cd458534abd81322f4d4cb3a40690254f8d9044ff449f328a8
   languageName: node
   linkType: hard
 
-"tmpl@npm:1.0.5":
-  version: 1.0.5
-  resolution: "tmpl@npm:1.0.5"
-  checksum: cd922d9b853c00fe414c5a774817be65b058d54a2d01ebb415840960406c669a0fc632f66df885e24cb022ec812739199ccbdb8d1164c3e513f85bfca5ab2873
+"tinyrainbow@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "tinyrainbow@npm:1.2.0"
+  checksum: d1e2cb5400032c0092be00e4a3da5450bea8b4fad58bfb5d3c58ca37ff5c5e252f7fcfb9af247914854af79c46014add9d1042fe044358c305a129ed55c8be35
+  languageName: node
+  linkType: hard
+
+"tinyspy@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "tinyspy@npm:3.0.2"
+  checksum: 5db671b2ff5cd309de650c8c4761ca945459d7204afb1776db9a04fb4efa28a75f08517a8620c01ee32a577748802231ad92f7d5b194dc003ee7f987a2a06337
   languageName: node
   linkType: hard
 
@@ -26009,39 +25202,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:^29.1.2":
-  version: 29.1.2
-  resolution: "ts-jest@npm:29.1.2"
-  dependencies:
-    bs-logger: 0.x
-    fast-json-stable-stringify: 2.x
-    jest-util: ^29.0.0
-    json5: ^2.2.3
-    lodash.memoize: 4.x
-    make-error: 1.x
-    semver: ^7.5.3
-    yargs-parser: ^21.0.1
-  peerDependencies:
-    "@babel/core": ">=7.0.0-beta.0 <8"
-    "@jest/types": ^29.0.0
-    babel-jest: ^29.0.0
-    jest: ^29.0.0
-    typescript: ">=4.3 <6"
-  peerDependenciesMeta:
-    "@babel/core":
-      optional: true
-    "@jest/types":
-      optional: true
-    babel-jest:
-      optional: true
-    esbuild:
-      optional: true
-  bin:
-    ts-jest: cli.js
-  checksum: a0ce0affc1b716c78c9ab55837829c42cb04b753d174a5c796bb1ddf9f0379fc20647b76fbe30edb30d9b23181908138d6b4c51ef2ae5e187b66635c295cefd5
-  languageName: node
-  linkType: hard
-
 "ts-node@npm:^10.8.1, ts-node@npm:^10.9.1, ts-node@npm:^10.9.2":
   version: 10.9.2
   resolution: "ts-node@npm:10.9.2"
@@ -26143,13 +25303,6 @@ __metadata:
   dependencies:
     prelude-ls: ^1.2.1
   checksum: ec688ebfc9c45d0c30412e41ca9c0cdbd704580eb3a9ccf07b9b576094d7b86a012baebc95681999dd38f4f444afd28504cb3a89f2ef16b31d4ab61a0739025a
-  languageName: node
-  linkType: hard
-
-"type-detect@npm:4.0.8":
-  version: 4.0.8
-  resolution: "type-detect@npm:4.0.8"
-  checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15
   languageName: node
   linkType: hard
 
@@ -26880,26 +26033,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"utf-8-validate@npm:5.0.7":
-  version: 5.0.7
-  resolution: "utf-8-validate@npm:5.0.7"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 588d272b359bf555a0c4c2ffe97286edc73126de132f63f4f0c80110bd06b67d3ce44d2b3d24feea6da13ced50c04d774ba4d25fe28576371cd714cd013bd3b7
-  languageName: node
-  linkType: hard
-
-"utf-8-validate@npm:6.0.3":
-  version: 6.0.3
-  resolution: "utf-8-validate@npm:6.0.3"
-  dependencies:
-    node-gyp: latest
-    node-gyp-build: ^4.3.0
-  checksum: 5e21383c81ff7469c1912119ca69d07202d944c73ddd8a54b84dddcc546b939054e5101c78c294e494d206fe93bd43428adc635a0660816b3ec9c8ec89286ac4
-  languageName: node
-  linkType: hard
-
 "utf-8-validate@npm:^5.0.2":
   version: 5.0.10
   resolution: "utf-8-validate@npm:5.0.10"
@@ -26989,17 +26122,6 @@ __metadata:
   version: 3.0.1
   resolution: "v8-compile-cache-lib@npm:3.0.1"
   checksum: 78089ad549e21bcdbfca10c08850022b22024cdcc2da9b168bcf5a73a6ed7bf01a9cebb9eac28e03cd23a684d81e0502797e88f3ccd27a32aeab1cfc44c39da0
-  languageName: node
-  linkType: hard
-
-"v8-to-istanbul@npm:^9.0.1":
-  version: 9.2.0
-  resolution: "v8-to-istanbul@npm:9.2.0"
-  dependencies:
-    "@jridgewell/trace-mapping": ^0.3.12
-    "@types/istanbul-lib-coverage": ^2.0.1
-    convert-source-map: ^2.0.0
-  checksum: 31ef98c6a31b1dab6be024cf914f235408cd4c0dc56a5c744a5eea1a9e019ba279e1b6f90d695b78c3186feed391ed492380ccf095009e2eb91f3d058f0b4491
   languageName: node
   linkType: hard
 
@@ -27126,6 +26248,114 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite-node@npm:2.1.9":
+  version: 2.1.9
+  resolution: "vite-node@npm:2.1.9"
+  dependencies:
+    cac: ^6.7.14
+    debug: ^4.3.7
+    es-module-lexer: ^1.5.4
+    pathe: ^1.1.2
+    vite: ^5.0.0
+  bin:
+    vite-node: vite-node.mjs
+  checksum: 716d37649834ecea547b43121ee89b2e4f9ca65ff6ce26214770ecfefe070b8c7245c9fdd0f92fb232d266e153629d04af9a4dc4fc350abfa521e5e46434b7b2
+  languageName: node
+  linkType: hard
+
+"vite@npm:^5.0.0":
+  version: 5.4.21
+  resolution: "vite@npm:5.4.21"
+  dependencies:
+    esbuild: ^0.21.3
+    fsevents: ~2.3.3
+    postcss: ^8.4.43
+    rollup: ^4.20.0
+  peerDependencies:
+    "@types/node": ^18.0.0 || >=20.0.0
+    less: "*"
+    lightningcss: ^1.21.0
+    sass: "*"
+    sass-embedded: "*"
+    stylus: "*"
+    sugarss: "*"
+    terser: ^5.4.0
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    less:
+      optional: true
+    lightningcss:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 7177fa03cff6a382f225290c9889a0d0e944d17eab705bcba89b58558a6f7adfa1f47e469b88f42a044a0eb40c12a1bf68b3cb42abb5295d04f9d7d4dd320837
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^2.1.0":
+  version: 2.1.9
+  resolution: "vitest@npm:2.1.9"
+  dependencies:
+    "@vitest/expect": 2.1.9
+    "@vitest/mocker": 2.1.9
+    "@vitest/pretty-format": ^2.1.9
+    "@vitest/runner": 2.1.9
+    "@vitest/snapshot": 2.1.9
+    "@vitest/spy": 2.1.9
+    "@vitest/utils": 2.1.9
+    chai: ^5.1.2
+    debug: ^4.3.7
+    expect-type: ^1.1.0
+    magic-string: ^0.30.12
+    pathe: ^1.1.2
+    std-env: ^3.8.0
+    tinybench: ^2.9.0
+    tinyexec: ^0.3.1
+    tinypool: ^1.0.1
+    tinyrainbow: ^1.2.0
+    vite: ^5.0.0
+    vite-node: 2.1.9
+    why-is-node-running: ^2.3.0
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@types/node": ^18.0.0 || >=20.0.0
+    "@vitest/browser": 2.1.9
+    "@vitest/ui": 2.1.9
+    happy-dom: "*"
+    jsdom: "*"
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+  bin:
+    vitest: vitest.mjs
+  checksum: 20db77529f843930ef1626103c898b27528d6d68d6c44753ec823e318f26bbdeb3bc56e6fb80e3f1ecc34382107d32e1f4e709e23198f414fecc9298ab225fa8
+  languageName: node
+  linkType: hard
+
 "vscode-jsonrpc@npm:8.2.0":
   version: 8.2.0
   resolution: "vscode-jsonrpc@npm:8.2.0"
@@ -27198,15 +26428,6 @@ __metadata:
   version: 3.0.1
   resolution: "walk-up-path@npm:3.0.1"
   checksum: 9ffca02fe30fb65f6db531260582988c5e766f4c739cf86a6109380a7f791236b5d0b92b1dce37a6f73e22dca6bc9d93bf3700413e16251b2bd6bbd1ca2be316
-  languageName: node
-  linkType: hard
-
-"walker@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "walker@npm:1.0.8"
-  dependencies:
-    makeerror: 1.0.12
-  checksum: ad7a257ea1e662e57ef2e018f97b3c02a7240ad5093c392186ce0bcf1f1a60bbadd520d073b9beb921ed99f64f065efb63dfc8eec689a80e569f93c1c5d5e16c
   languageName: node
   linkType: hard
 
@@ -27630,6 +26851,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: ^2.0.0
+    stackback: 0.0.2
+  bin:
+    why-is-node-running: cli.js
+  checksum: 58ebbf406e243ace97083027f0df7ff4c2108baf2595bb29317718ef207cc7a8104e41b711ff65d6fa354f25daa8756b67f2f04931a4fd6ba9d13ae8197496fb
+  languageName: node
+  linkType: hard
+
 "wide-align@npm:^1.1.5":
   version: 1.1.5
   resolution: "wide-align@npm:1.1.5"
@@ -27714,16 +26947,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"write-file-atomic@npm:^4.0.2":
-  version: 4.0.2
-  resolution: "write-file-atomic@npm:4.0.2"
-  dependencies:
-    imurmurhash: ^0.1.4
-    signal-exit: ^3.0.7
-  checksum: 5da60bd4eeeb935eec97ead3df6e28e5917a6bd317478e4a85a5285e8480b8ed96032bbcc6ecd07b236142a24f3ca871c924ec4a6575e623ec1b11bf8c1c253c
-  languageName: node
-  linkType: hard
-
 "write-file-atomic@npm:^5.0.0, write-file-atomic@npm:^5.0.1":
   version: 5.0.1
   resolution: "write-file-atomic@npm:5.0.1"
@@ -27746,21 +26969,6 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 3a990b32ed08c72070d5e8913e14dfcd831919205be52a3ff0b4cdd998c8d554f167c9df3841605cde8b11d607768cacab3e823c58c96a5c08c987e093eb767a
-  languageName: node
-  linkType: hard
-
-"ws@npm:8.13.0":
-  version: 8.13.0
-  resolution: "ws@npm:8.13.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 53e991bbf928faf5dc6efac9b8eb9ab6497c69feeb94f963d648b7a3530a720b19ec2e0ec037344257e05a4f35bd9ad04d9de6f289615ffb133282031b18c61c
   languageName: node
   linkType: hard
 
@@ -27806,6 +27014,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.13.0":
+  version: 8.20.0
+  resolution: "ws@npm:8.20.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 2b31d24a53690770564a033c21ea48390f84d23fbc5abc14b2bbec4e112846f2f3ca66caee769a73fb8bc89ba16b452a6911a553e9742bbc75bccb79e203953e
   languageName: node
   linkType: hard
 
@@ -27941,7 +27164,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.0.1, yargs-parser@npm:^21.1.1":
+"yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
@@ -27967,7 +27190,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.0.0, yargs@npm:^17.3.1, yargs@npm:^17.5.1":
+"yargs@npm:^17.0.0, yargs@npm:^17.5.1":
   version: 17.7.2
   resolution: "yargs@npm:17.7.2"
   dependencies:


### PR DESCRIPTION
### Description

- Replace jest/ts-jest with vitest@^2.1.0
  - vitest.config.ts: esbuild target es2022 (for accessor keyword), singleFork mode, globalSetup for Anvil lifecycle
  - Bulk-migrate all 27 test files and expect utilities: @jest/globals → vitest, jest.fn/spyOn/setTimeout → vi.*
  - Convert multiformats.mock.cjs (jest.mock) → multiformats.mock.ts (vi.mock)
  - Remove xtest, fix dual-governance multi-line spyOn

- Replace ganache with @viem/anvil
  - Anvil started in globalSetup with proper teardown via return function
  - Port communicated via process.env.VITEST_ANVIL_PORT (inherited by forks)
  - Fixture files use http() transport instead of in-process EIP-1193 provider
  - createTestClient mode: 'ganache' → 'anvil'

- Add stvault unit tests (44 tests, all passing)
  - calculate-health.test.ts: pure calculateHealth() function (9 tests)
  - report-proof.test.ts: Merkle proof utils with real StandardMerkleTree (12 tests)
  - vault-entity.test.ts: calculateOverview() and calculateHealth() methods (14 tests)
  - vault-constants.test.ts: consts/common and consts/roles (9 tests)

### Demo

<!-- If thee are visual changes add screenshots or record a [loom](https://www.loom.com/). -->

### Code review notes

<!-- Describe all uncertain decisions you made code-wise, e.g. readability vs performance. -->

### Testing notes

<!-- List all possible edge cases and how to test them. -->

### Checklist:

- [ ]  Checked the changes locally.
- [ ]  Created/updated unit tests.
- [ ]  Created/updated README.md.

