### PR TITLE
fix(stvault): exported type `FundPros` is missing a letter

### DIFF
--- a/packages/sdk/src/stvault/types.ts
+++ b/packages/sdk/src/stvault/types.ts
@@ -65,7 +65,7 @@ export type CreateVaultProps = CommonTransactionProps & {
 
 export type CreateVaultResult = LidoSDKVaultEntity;
 
-export type FundPros = CommonTransactionProps & {
+export type FundProps = CommonTransactionProps & {
   value: bigint;
 };
 

--- a/packages/sdk/src/stvault/vault-entity.ts
+++ b/packages/sdk/src/stvault/vault-entity.ts
@@ -9,7 +9,7 @@ import { BusModule } from './bus-module.js';
 import {
   BurnProps,
   BurnSharesProps,
-  FundPros,
+  FundProps,
   GetLatestVaultReportProps,
   GetVaultRoleMembersProps,
   LidoSDKVaultsModuleProps,
@@ -154,7 +154,7 @@ export class LidoSDKVaultEntity extends BusModule {
   // fund methods
   @Logger('Call:')
   @ErrorHandler()
-  public async fund(props: FundPros): Promise<TransactionResult> {
+  public async fund(props: FundProps): Promise<TransactionResult> {
     const parsedProps = await this.parseProps(props);
 
     return this.bus.core.performTransaction({
@@ -171,7 +171,7 @@ export class LidoSDKVaultEntity extends BusModule {
 
   @Logger('Utils:')
   @ErrorHandler()
-  public async fundPopulateTx(props: FundPros): Promise<PopulatedTransaction> {
+  public async fundPopulateTx(props: FundProps): Promise<PopulatedTransaction> {
     const parsedProps = await this.parseProps(props);
 
     return {
@@ -188,7 +188,7 @@ export class LidoSDKVaultEntity extends BusModule {
 
   @Logger('Call:')
   @ErrorHandler()
-  public async fundSimulateTx(props: FundPros) {
+  public async fundSimulateTx(props: FundProps) {
     const { dashboard, account } = await this.parseProps(props);
     return await dashboard.simulate.fund({
       account,


### PR DESCRIPTION
## Problem

`packages/sdk/src/stvault/types.ts:68` declares:

```ts
export type FundPros = CommonTransactionProps & {
  value: bigint;
};
```

`FundPros` should be `FundProps`. Every other props type in that same file follows the `*Props` convention — `CreateVaultProps`, `WithdrawProps`, `MintSharesProps`, `BurnProps`, `SetRolesProps`, and about fifteen more. This one is the only exception, and it reads as a slip rather than a deliberate name.

It is not purely cosmetic: `stvault/index.ts` does `export * from './types.js'` and the SDK root re-exports the module (`packages/sdk/src/index.ts:15`), so `FundPros` is part of the published type surface. Anyone typing the argument of `vault.fund()` has to spell the typo.

## Fix

Rename the type and its four uses in `vault-entity.ts` (the import plus the `fund`, `fundPopulateTx` and `fundSimulateTx` signatures). Five lines, two files, no behaviour change.

I confirmed there is no existing `FundProps` anywhere in the repo, so nothing collides, and the import list stays alphabetically ordered after the rename.

## On backwards compatibility

If `FundPros` has already gone out in a published release, this is technically a breaking change to the type surface. Say the word and I will add

```ts
/** @deprecated use {@link FundProps} */
export type FundPros = FundProps;
```

so existing consumers keep compiling. I left it out to keep the diff minimal, since you will know immediately whether the type has shipped and I could not check the registry from here.

Targeted at `develop`, matching the default branch.