### PR TITLE
Add pending owner functionality to SDK

### DIFF
--- a/docs/sdk/get-started/error-codes.md
+++ b/docs/sdk/get-started/error-codes.md
@@ -4,8 +4,53 @@ sidebar_position: 3
 
 # Error Codes
 
+Every error thrown by the SDK is an `SDKError` carrying a `code` and,
+sometimes, a more specific `reason`.
+
+## `code` — broad category
+
 - **INVALID_ARGUMENT**: arguments passed to SDK method are not valid
 - **NOT_SUPPORTED**: behavior or feature though possible is not currently supported by SDK
 - **PROVIDER_ERROR**: error with RPC or Web3 Provider
 - **READ_ERROR**: error while accessing Blockchain or External Resource for read
 - **UNKNOWN_ERROR** error was not recognized by SDK and is not directly thrown by it's code
+
+## `reason` — specific condition
+
+Several distinct conditions share a single `code`, so `code` alone cannot tell
+them apart. Where it matters, the SDK also sets `reason` — a stable
+machine-readable string you can switch on, for example to map an SDK failure
+onto your own error taxonomy or pick a specific message in a UI.
+
+`reason` is optional: it is `undefined` for errors that have no more specific
+condition to report. Each module owns its own vocabulary and exports it as a
+typed union.
+
+stVaults (`@lidofinance/lido-ethereum-sdk/stvault`, `VaultErrorReason`):
+
+- **OWNER_NOT_DASHBOARD**: the vault's owner is not a Dashboard contract — its
+  bytecode does not match the canonical Dashboard clone proxy
+- **DASHBOARD_NOT_BELONG_TO_VAULT**: the address is a Dashboard, but its
+  `stakingVault()` points at a different vault, so it does not control this one
+
+```ts
+import { VAULT_ERROR_REASON } from '@lidofinance/lido-ethereum-sdk/stvault';
+import { SDKError } from '@lidofinance/lido-ethereum-sdk/common';
+
+try {
+  await vaultEntity.getDashboardAddress();
+} catch (error) {
+  if (error instanceof SDKError) {
+    switch (error.reason) {
+      case VAULT_ERROR_REASON.OWNER_NOT_DASHBOARD:
+        // the owner is not a Dashboard at all
+        break;
+      case VAULT_ERROR_REASON.DASHBOARD_NOT_BELONG_TO_VAULT:
+        // it is a Dashboard, but for a different vault
+        break;
+      default:
+        // fall back to error.code
+    }
+  }
+}
+```

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,3 +1,26 @@
+# 4.9.0
+
+## SDK
+
+### Added
+
+- Move vault Dashboard resolution and verification into the SDK.
+    - getDashboardAddress(props?) now resolves pending-owner Dashboards after voluntary disconnect and batches owner/connection reads.
+    - isDashboard(address, props?) is now public and block-aware.
+    - Added isDashboardBelongsToVault(dashboardAddress, props?).
+    - Dashboard-vault linkage is enforced during resolution, gated by skipDashboardCheck.
+- Added SDKError.reason with stVault reasons:
+    - OWNER_NOT_DASHBOARD
+    - DASHBOARD_NOT_BELONG_TO_VAULT
+- Exported BlockNumberProps.
+- getVaultOverviewData now performs Dashboard reads at its own blockNumber.
+- Restructured error-code docs into code and reason sections.
+
+### Fixed
+
+- Fixed unhandled rejection in @Cache-decorated methods.
+
+
 # 4.8.0
 
 ## SDK

--- a/packages/sdk/src/common/decorators/cache.ts
+++ b/packages/sdk/src/common/decorators/cache.ts
@@ -73,8 +73,16 @@ export const Cache = function (timeMs = 0, cacheArgs?: string[]) {
       );
       const result = originalMethod.call(this, ...args);
       if (result instanceof Promise) {
-        void result.then((resolvedResult) =>
-          cache.set(cacheKey, { data: resolvedResult, timestamp: Date.now() }),
+        // only successful results are cached; the rejection handler is required
+        // so this observer promise does not surface as an unhandled rejection
+        // (the rejection itself is still delivered to the caller via `result`)
+        void result.then(
+          (resolvedResult) =>
+            cache.set(cacheKey, {
+              data: resolvedResult,
+              timestamp: Date.now(),
+            }),
+          () => undefined,
         );
       } else cache.set(cacheKey, { data: result, timestamp: Date.now() });
 

--- a/packages/sdk/src/common/utils/sdk-error.ts
+++ b/packages/sdk/src/common/utils/sdk-error.ts
@@ -8,10 +8,13 @@ export enum ERROR_CODE {
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
 }
 
+export type SDKErrorReason = string;
+
 export type SDKErrorProps = {
   code?: ERROR_CODE;
   error?: unknown;
   message?: string;
+  reason?: SDKErrorReason;
 };
 
 export class SDKError extends Error {
@@ -35,8 +38,9 @@ export class SDKError extends Error {
 
   public code: ERROR_CODE;
   public errorMessage: string | undefined;
+  public reason: SDKErrorReason | undefined;
 
-  constructor({ code, error = {}, message }: SDKErrorProps) {
+  constructor({ code, error = {}, message, reason }: SDKErrorProps) {
     super(message);
     if (error instanceof Error) {
       this.cause = error.cause;
@@ -44,6 +48,7 @@ export class SDKError extends Error {
     }
     this.code = code ?? ERROR_CODE.UNKNOWN_ERROR;
     this.errorMessage = message;
+    this.reason = reason;
   }
 }
 // invariant that throws SDK ERROR

--- a/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
+++ b/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
@@ -3,7 +3,11 @@ import { isAddressEqual, zeroAddress, type Address } from 'viem';
 import { LidoSDKVaultEntity } from '../vault-entity.js';
 import type { OverviewArgs } from '../utils/overview/types.js';
 import type { Bus } from '../bus.js';
-import { PROXY_CODE_PAD_LEFT, PROXY_CODE_PAD_RIGHT } from '../consts/index.js';
+import {
+  PROXY_CODE_PAD_LEFT,
+  PROXY_CODE_PAD_RIGHT,
+  VAULT_ERROR_REASON,
+} from '../consts/index.js';
 import { ERROR_CODE, SDKError } from '../../common/utils/sdk-error.js';
 
 // ─── Minimal mock bus ────────────────────────────────────────────────────────
@@ -208,6 +212,8 @@ const DASHBOARD_PROXY_CODE =
   DASHBOARD_IMPL.slice(2).toLowerCase() +
   PROXY_CODE_PAD_RIGHT;
 
+const OTHER_VAULT = '0x9999999999999999999999999999999999999999' as Address;
+
 type StubOptions = {
   isVaultConnected: boolean;
   vaultOwner: Address;
@@ -215,11 +221,17 @@ type StubOptions = {
   pendingOwner?: Address;
   /** addresses whose deployed bytecode is the Dashboard clone proxy */
   dashboards?: Address[];
+  /**
+   * Dashboard address (lowercased) -> the vault its `stakingVault()` returns.
+   * Anything not listed points back at VAULT_ADDRESS, i.e. correct linkage.
+   */
+  stakingVaultOf?: Record<string, Address>;
   skipDashboardCheck?: boolean;
 };
 
 const makeDashboardEntity = (opts: StubOptions) => {
   const dashboards = opts.dashboards ?? [];
+  const stakingVaultOf = opts.stakingVaultOf ?? {};
 
   const getCode = vi.fn(
     async ({
@@ -253,8 +265,20 @@ const makeDashboardEntity = (opts: StubOptions) => {
     },
   );
   const dashboardImpl = vi.fn(async () => DASHBOARD_IMPL);
+
+  // the real contract's read.stakingVault() takes no address, so the spy is
+  // called with the bound dashboard address to make assertions readable
+  const stakingVault = vi.fn(
+    async (address: Address, _options?: { blockNumber?: bigint }) => {
+      return stakingVaultOf[address.toLowerCase()] ?? VAULT_ADDRESS;
+    },
+  );
   const getContractVaultDashboard = vi.fn(async (address: Address) => ({
     address,
+    read: {
+      stakingVault: (options?: { blockNumber?: bigint }) =>
+        stakingVault(address, options),
+    },
   }));
 
   const bus = {
@@ -293,6 +317,7 @@ const makeDashboardEntity = (opts: StubOptions) => {
       isVaultConnected,
       vaultConnection,
       dashboardImpl,
+      stakingVault,
       getContractVaultDashboard,
     },
   };
@@ -382,6 +407,7 @@ describe('LidoSDKVaultEntity.getDashboardAddress', () => {
 
     await expect(entity.getDashboardAddress()).rejects.toMatchObject({
       code: ERROR_CODE.NOT_SUPPORTED,
+      reason: VAULT_ERROR_REASON.OWNER_NOT_DASHBOARD,
     });
   });
 
@@ -464,5 +490,191 @@ describe('LidoSDKVaultEntity.isDashboard', () => {
     // one getCode per call, but the factory's DASHBOARD_IMPL is read once
     expect(mocks.getCode).toHaveBeenCalledTimes(2);
     expect(mocks.dashboardImpl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('LidoSDKVaultEntity.isDashboardBelongsToVault', () => {
+  test('true when the Dashboard points back at this vault', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+    });
+
+    await expect(
+      entity.isDashboardBelongsToVault(DASHBOARD_ADDRESS),
+    ).resolves.toBe(true);
+  });
+
+  test('false when the Dashboard points at another vault', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+      stakingVaultOf: { [DASHBOARD_ADDRESS.toLowerCase()]: OTHER_VAULT },
+    });
+
+    await expect(
+      entity.isDashboardBelongsToVault(DASHBOARD_ADDRESS),
+    ).resolves.toBe(false);
+  });
+
+  test('forwards blockNumber to the stakingVault read', async () => {
+    const blockNumber = 21_000_000n;
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+    });
+
+    await entity.isDashboardBelongsToVault(DASHBOARD_ADDRESS, { blockNumber });
+
+    expect(mocks.stakingVault).toHaveBeenCalledWith(DASHBOARD_ADDRESS, {
+      blockNumber,
+    });
+  });
+});
+
+/** Resolves the SDKError a failing resolution rejects with. */
+const captureError = async (
+  entity: LidoSDKVaultEntity,
+): Promise<SDKError> => {
+  const result = await entity.getDashboardAddress().then(
+    () => null,
+    (error: unknown) => error,
+  );
+  expect(result).toBeInstanceOf(SDKError);
+
+  return result as SDKError;
+};
+
+describe('LidoSDKVaultEntity.getDashboardAddress linkage enforcement', () => {
+  test('strict: throws when the owner Dashboard belongs to another vault', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+      stakingVaultOf: { [DASHBOARD_ADDRESS.toLowerCase()]: OTHER_VAULT },
+      skipDashboardCheck: false,
+    });
+
+    await expect(entity.getDashboardAddress()).rejects.toMatchObject({
+      code: ERROR_CODE.NOT_SUPPORTED,
+      reason: VAULT_ERROR_REASON.DASHBOARD_NOT_BELONG_TO_VAULT,
+    });
+  });
+
+  test('strict: throws when the pending-owner Dashboard belongs to another vault', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: PENDING_DASHBOARD,
+      dashboards: [PENDING_DASHBOARD],
+      stakingVaultOf: { [PENDING_DASHBOARD.toLowerCase()]: OTHER_VAULT },
+      skipDashboardCheck: false,
+    });
+
+    await expect(entity.getDashboardAddress()).rejects.toMatchObject({
+      code: ERROR_CODE.NOT_SUPPORTED,
+      reason: VAULT_ERROR_REASON.DASHBOARD_NOT_BELONG_TO_VAULT,
+    });
+  });
+
+  test('the two failure conditions are distinguishable by reason', async () => {
+    // both throws share code NOT_SUPPORTED, so `reason` is the only thing a
+    // consumer can switch on to pick the right message/UI
+    const ownerNotDashboard = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: EOA_ADDRESS,
+      dashboards: [],
+      skipDashboardCheck: false,
+    });
+    const notBelongToVault = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+      stakingVaultOf: { [DASHBOARD_ADDRESS.toLowerCase()]: OTHER_VAULT },
+      skipDashboardCheck: false,
+    });
+
+    const first = await captureError(ownerNotDashboard.entity);
+    const second = await captureError(notBelongToVault.entity);
+
+    expect(first.code).toBe(second.code);
+    expect(first.reason).toBe(VAULT_ERROR_REASON.OWNER_NOT_DASHBOARD);
+    expect(second.reason).toBe(
+      VAULT_ERROR_REASON.DASHBOARD_NOT_BELONG_TO_VAULT,
+    );
+  });
+
+  test('strict: resolves normally when the linkage matches', async () => {
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+      skipDashboardCheck: false,
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(DASHBOARD_ADDRESS);
+    expect(mocks.stakingVault).toHaveBeenCalledWith(
+      DASHBOARD_ADDRESS,
+      expect.anything(),
+    );
+  });
+
+  test('strict: forwards blockNumber into the linkage read', async () => {
+    const blockNumber = 21_000_000n;
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+      skipDashboardCheck: false,
+    });
+
+    await entity.getDashboardAddress({ blockNumber });
+
+    expect(mocks.stakingVault).toHaveBeenCalledWith(DASHBOARD_ADDRESS, {
+      blockNumber,
+    });
+  });
+
+  test('skipDashboardCheck: resolves a mismatched Dashboard without reading stakingVault', async () => {
+    // the widget's mode — it runs the check itself so it can throw its own error
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+      stakingVaultOf: { [DASHBOARD_ADDRESS.toLowerCase()]: OTHER_VAULT },
+      skipDashboardCheck: true,
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(DASHBOARD_ADDRESS);
+    expect(mocks.stakingVault).not.toHaveBeenCalled();
+  });
+
+  test('strict: the non-Dashboard fallback never reads stakingVault', async () => {
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: EOA_ADDRESS,
+      dashboards: [],
+      skipDashboardCheck: false,
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(EOA_ADDRESS);
+    expect(mocks.stakingVault).not.toHaveBeenCalled();
+  });
+
+  test('an explicitly supplied dashboardAddress is not linkage-checked', async () => {
+    const bus = {
+      core: { logMode: 'none', chain: { id: 1 } },
+      contracts: {},
+    } as unknown as Bus;
+    const entity = new LidoSDKVaultEntity({
+      bus,
+      vaultAddress: VAULT_ADDRESS,
+      dashboardAddress: DASHBOARD_ADDRESS,
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(DASHBOARD_ADDRESS);
   });
 });

--- a/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
+++ b/packages/sdk/src/stvault/__tests__/vault-entity.test.ts
@@ -1,8 +1,10 @@
-import { describe, test, expect } from 'vitest';
-import type { Address } from 'viem';
+import { describe, test, expect, vi } from 'vitest';
+import { isAddressEqual, zeroAddress, type Address } from 'viem';
 import { LidoSDKVaultEntity } from '../vault-entity.js';
 import type { OverviewArgs } from '../utils/overview/types.js';
 import type { Bus } from '../bus.js';
+import { PROXY_CODE_PAD_LEFT, PROXY_CODE_PAD_RIGHT } from '../consts/index.js';
+import { ERROR_CODE, SDKError } from '../../common/utils/sdk-error.js';
 
 // ─── Minimal mock bus ────────────────────────────────────────────────────────
 // calculateOverview and calculateHealth are pure synchronous methods that do
@@ -188,5 +190,279 @@ describe('LidoSDKVaultEntity.calculateOverview', () => {
     });
     const result = entity.calculateOverview(args);
     expect(result.collateral).toBe(largeMinimalReserve);
+  });
+});
+
+// ─── Dashboard resolution ────────────────────────────────────────────────────
+// getDashboardAddress does touch this.bus, so these tests need a stub bus
+// exposing the contracts and the publicClient.getCode it reads.
+
+const HUB_ADDRESS = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address;
+const DASHBOARD_ADDRESS = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address;
+const PENDING_DASHBOARD = '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' as Address;
+const EOA_ADDRESS = '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE' as Address;
+const DASHBOARD_IMPL = '0x1111111111111111111111111111111111111111' as Address;
+
+const DASHBOARD_PROXY_CODE =
+  PROXY_CODE_PAD_LEFT +
+  DASHBOARD_IMPL.slice(2).toLowerCase() +
+  PROXY_CODE_PAD_RIGHT;
+
+type StubOptions = {
+  isVaultConnected: boolean;
+  vaultOwner: Address;
+  vaultConnectionOwner?: Address;
+  pendingOwner?: Address;
+  /** addresses whose deployed bytecode is the Dashboard clone proxy */
+  dashboards?: Address[];
+  skipDashboardCheck?: boolean;
+};
+
+const makeDashboardEntity = (opts: StubOptions) => {
+  const dashboards = opts.dashboards ?? [];
+
+  const getCode = vi.fn(
+    async ({
+      address,
+      blockNumber,
+    }: {
+      address: Address;
+      blockNumber?: bigint;
+    }) => {
+      void blockNumber;
+      return dashboards.some((d) => isAddressEqual(d, address))
+        ? DASHBOARD_PROXY_CODE
+        : '0xdeadbeef';
+    },
+  );
+
+  const owner = vi.fn(async (_options?: { blockNumber?: bigint }) => {
+    return opts.vaultOwner;
+  });
+  const pendingOwner = vi.fn(async (_options?: { blockNumber?: bigint }) => {
+    return opts.pendingOwner ?? zeroAddress;
+  });
+  const isVaultConnected = vi.fn(
+    async (_args: [Address], _options?: { blockNumber?: bigint }) => {
+      return opts.isVaultConnected;
+    },
+  );
+  const vaultConnection = vi.fn(
+    async (_args: [Address], _options?: { blockNumber?: bigint }) => {
+      return { owner: opts.vaultConnectionOwner ?? zeroAddress };
+    },
+  );
+  const dashboardImpl = vi.fn(async () => DASHBOARD_IMPL);
+  const getContractVaultDashboard = vi.fn(async (address: Address) => ({
+    address,
+  }));
+
+  const bus = {
+    core: {
+      logMode: 'none',
+      chain: { id: 1 },
+      publicClient: { getCode },
+      error: (props: { code: ERROR_CODE; message: string }) =>
+        new SDKError(props),
+    },
+    contracts: {
+      getContractVaultHub: async () => ({
+        address: HUB_ADDRESS,
+        read: { isVaultConnected, vaultConnection },
+      }),
+      getContractVault: async () => ({ read: { owner, pendingOwner } }),
+      getContractVaultFactory: async () => ({
+        read: { DASHBOARD_IMPL: dashboardImpl },
+      }),
+      getContractVaultDashboard,
+    },
+  } as unknown as Bus;
+
+  const entity = new LidoSDKVaultEntity({
+    bus,
+    vaultAddress: VAULT_ADDRESS,
+    skipDashboardCheck: opts.skipDashboardCheck ?? true,
+  });
+
+  return {
+    entity,
+    mocks: {
+      getCode,
+      owner,
+      pendingOwner,
+      isVaultConnected,
+      vaultConnection,
+      dashboardImpl,
+      getContractVaultDashboard,
+    },
+  };
+};
+
+describe('LidoSDKVaultEntity.getDashboardAddress', () => {
+  test('returns the vault owner when it is a Dashboard', async () => {
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(DASHBOARD_ADDRESS);
+    // the pending-owner fallback must not cost an extra read on the happy path
+    expect(mocks.pendingOwner).not.toHaveBeenCalled();
+  });
+
+  test('vaultConnection.owner wins over the vault owner', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultConnectionOwner: DASHBOARD_ADDRESS,
+      vaultOwner: EOA_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(DASHBOARD_ADDRESS);
+  });
+
+  test('falls back to the pending owner when the VaultHub holds the vault', async () => {
+    // the state after voluntaryDisconnect() but before acceptOwnership()
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: PENDING_DASHBOARD,
+      dashboards: [PENDING_DASHBOARD],
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(
+      PENDING_DASHBOARD,
+    );
+    expect(mocks.pendingOwner).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not use the pending owner when it is not a Dashboard', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: EOA_ADDRESS,
+      dashboards: [],
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(HUB_ADDRESS);
+  });
+
+  test('does not read the pending owner when the vault is still connected', async () => {
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: PENDING_DASHBOARD,
+      dashboards: [PENDING_DASHBOARD],
+      skipDashboardCheck: true,
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(HUB_ADDRESS);
+    expect(mocks.pendingOwner).not.toHaveBeenCalled();
+  });
+
+  test('falls through with a zero pending owner and skipDashboardCheck', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: zeroAddress,
+      dashboards: [],
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(HUB_ADDRESS);
+  });
+
+  test('throws NOT_SUPPORTED when connected to a non-Dashboard owner', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: EOA_ADDRESS,
+      dashboards: [],
+      skipDashboardCheck: false,
+    });
+
+    await expect(entity.getDashboardAddress()).rejects.toMatchObject({
+      code: ERROR_CODE.NOT_SUPPORTED,
+    });
+  });
+
+  test('forwards blockNumber to getCode and to the hub/vault reads', async () => {
+    const blockNumber = 21_000_000n;
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: PENDING_DASHBOARD,
+      dashboards: [PENDING_DASHBOARD],
+    });
+
+    await entity.getDashboardAddress({ blockNumber });
+
+    expect(mocks.isVaultConnected).toHaveBeenCalledWith([VAULT_ADDRESS], {
+      blockNumber,
+    });
+    expect(mocks.vaultConnection).toHaveBeenCalledWith([VAULT_ADDRESS], {
+      blockNumber,
+    });
+    expect(mocks.owner).toHaveBeenCalledWith({ blockNumber });
+    expect(mocks.pendingOwner).toHaveBeenCalledWith({ blockNumber });
+    for (const call of mocks.getCode.mock.calls) {
+      expect(call[0]).toMatchObject({ blockNumber });
+    }
+  });
+
+  test('memoizes the resolved address across calls', async () => {
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: false,
+      vaultOwner: HUB_ADDRESS,
+      pendingOwner: PENDING_DASHBOARD,
+      dashboards: [PENDING_DASHBOARD],
+    });
+
+    await entity.getDashboardAddress();
+    await entity.getDashboardAddress();
+
+    expect(mocks.pendingOwner).toHaveBeenCalledTimes(1);
+  });
+
+  test('an explicitly supplied dashboardAddress short-circuits all reads', async () => {
+    // an empty contracts stub proves no read is attempted
+    const bus = {
+      core: { logMode: 'none', chain: { id: 1 } },
+      contracts: {},
+    } as unknown as Bus;
+    const entity = new LidoSDKVaultEntity({
+      bus,
+      vaultAddress: VAULT_ADDRESS,
+      dashboardAddress: DASHBOARD_ADDRESS,
+    });
+
+    await expect(entity.getDashboardAddress()).resolves.toBe(DASHBOARD_ADDRESS);
+  });
+});
+
+describe('LidoSDKVaultEntity.isDashboard', () => {
+  test('true for the Dashboard clone proxy bytecode', async () => {
+    const { entity } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+    });
+
+    await expect(entity.isDashboard(DASHBOARD_ADDRESS)).resolves.toBe(true);
+    await expect(entity.isDashboard(EOA_ADDRESS)).resolves.toBe(false);
+  });
+
+  test('caches the proxy code across calls', async () => {
+    const { entity, mocks } = makeDashboardEntity({
+      isVaultConnected: true,
+      vaultOwner: DASHBOARD_ADDRESS,
+      dashboards: [DASHBOARD_ADDRESS],
+    });
+
+    await entity.isDashboard(DASHBOARD_ADDRESS);
+    await entity.isDashboard(DASHBOARD_ADDRESS);
+
+    // one getCode per call, but the factory's DASHBOARD_IMPL is read once
+    expect(mocks.getCode).toHaveBeenCalledTimes(2);
+    expect(mocks.dashboardImpl).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/sdk/src/stvault/consts/errors.ts
+++ b/packages/sdk/src/stvault/consts/errors.ts
@@ -1,0 +1,21 @@
+/**
+ * Specific failure conditions the stVault module reports through
+ * `SDKError.reason`. `SDKError.code` stays a broad category, so these are what
+ * a consumer switches on to tell one condition from another — e.g. to pick the
+ * right message or UI for a Dashboard that failed verification.
+ */
+export const VAULT_ERROR_REASON = {
+  /**
+   * The vault's owner is not a Dashboard contract: its bytecode does not match
+   * the canonical Dashboard clone proxy.
+   */
+  OWNER_NOT_DASHBOARD: 'OWNER_NOT_DASHBOARD',
+  /**
+   * The address is a Dashboard, but its `stakingVault()` points at a different
+   * vault, so it does not control this one.
+   */
+  DASHBOARD_NOT_BELONG_TO_VAULT: 'DASHBOARD_NOT_BELONG_TO_VAULT',
+} as const;
+
+export type VaultErrorReason =
+  (typeof VAULT_ERROR_REASON)[keyof typeof VAULT_ERROR_REASON];

--- a/packages/sdk/src/stvault/consts/index.ts
+++ b/packages/sdk/src/stvault/consts/index.ts
@@ -1,2 +1,3 @@
 export * from './common.js';
+export * from './errors.js';
 export * from './roles.js';

--- a/packages/sdk/src/stvault/types.ts
+++ b/packages/sdk/src/stvault/types.ts
@@ -194,6 +194,14 @@ export type GetLatestVaultReportProps = {
   gateway?: string;
 };
 
+/**
+ * Pins the reads of a view method to a specific block. When omitted the reads
+ * are made at the latest block.
+ */
+export type BlockNumberProps = {
+  blockNumber?: bigint;
+};
+
 export type VaultReportProps = {
   vault: Address;
   cid: string;

--- a/packages/sdk/src/stvault/vault-entity.ts
+++ b/packages/sdk/src/stvault/vault-entity.ts
@@ -7,6 +7,7 @@ import {
 } from '../core/types.js';
 import { BusModule } from './bus-module.js';
 import {
+  BlockNumberProps,
   BurnProps,
   BurnSharesProps,
   FundPros,
@@ -93,10 +94,12 @@ export class LidoSDKVaultEntity extends BusModule {
   @Logger('Utils:')
   @Cache(30 * 60 * 1000, ['dashboardAddress'])
   @ErrorHandler()
-  public async getDashboardContract(): Promise<
+  public async getDashboardContract(
+    props?: BlockNumberProps,
+  ): Promise<
     EncodableContract<GetContractReturnType<typeof DashboardAbi, WalletClient>>
   > {
-    const dashboardAddress = await this.getDashboardAddress();
+    const dashboardAddress = await this.getDashboardAddress(props);
     if (!dashboardAddress) {
       throw this.bus.core.error({
         code: ERROR_CODE.READ_ERROR,
@@ -111,35 +114,77 @@ export class LidoSDKVaultEntity extends BusModule {
     return this.vaultAddress;
   }
 
+  /**
+   * The address expected to be the Dashboard: the owner recorded by the
+   * VaultHub when the vault is connected, otherwise the StakingVault's own
+   * owner.
+   */
+  private getSupposedDashboardAddress(
+    vaultConnectionOwner: Address,
+    vaultOwner: Address,
+  ): Address {
+    return !isAddressEqual(vaultConnectionOwner, zeroAddress)
+      ? vaultConnectionOwner
+      : vaultOwner;
+  }
+
+  /**
+   * Resolves the Dashboard address of the vault.
+   *
+   * Note: the resolved address is memoized on the instance, so `blockNumber`
+   * only affects the first resolution for a given entity. Construct a new
+   * entity to resolve against a different block.
+   */
   @Logger('Utils:')
   @Cache(30 * 60 * 1000, ['dashboardAddress'])
   @ErrorHandler()
-  public async getDashboardAddress(): Promise<Address> {
+  public async getDashboardAddress(props?: BlockNumberProps): Promise<Address> {
     if (this.dashboardAddress) {
       return this.dashboardAddress;
     }
 
+    const blockNumber = props?.blockNumber;
+    const callOptions = { blockNumber };
+
     const vaultHub = await this.bus.contracts.getContractVaultHub();
+    const vault = await this.getVaultContract();
 
-    const isVaultConnected = await vaultHub.read.isVaultConnected([
-      this.vaultAddress,
+    const [isVaultConnected, vaultConnection, vaultOwner] = await Promise.all([
+      vaultHub.read.isVaultConnected([this.vaultAddress], callOptions),
+      vaultHub.read.vaultConnection([this.vaultAddress], callOptions),
+      vault.read.owner(callOptions),
     ]);
 
-    const vaultConnection = await vaultHub.read.vaultConnection([
-      this.vaultAddress,
-    ]);
-    const vaultOwner = await (await this.getVaultContract()).read.owner();
-
-    const supposedDashboardAddress = !isAddressEqual(
+    const supposedDashboardAddress = this.getSupposedDashboardAddress(
       vaultConnection.owner,
-      zeroAddress,
-    )
-      ? vaultConnection.owner
-      : vaultOwner;
+      vaultOwner,
+    );
 
-    const isOwnerDashboard = await this.isDashboard(supposedDashboardAddress);
+    if (await this.isDashboard(supposedDashboardAddress, { blockNumber })) {
+      this.dashboardAddress = supposedDashboardAddress;
 
-    if (!isOwnerDashboard && isVaultConnected && !this.skipDashboardCheck) {
+      return this.dashboardAddress;
+    }
+
+    // The dashboard address is missing when `applyReport` is called after a
+    // voluntary disconnection: the VaultHub holds the vault's ownership and
+    // hands it back to the Dashboard with a 2-step transfer, so until
+    // `acceptOwnership` the Dashboard is only the pending owner.
+    if (!isVaultConnected && isAddressEqual(vaultOwner, vaultHub.address)) {
+      // the read is made only for this case, connected vaults never pay for it
+      const pendingOwner = await vault.read.pendingOwner(callOptions);
+
+      if (
+        !isAddressEqual(pendingOwner, zeroAddress) &&
+        (await this.isDashboard(pendingOwner, { blockNumber }))
+      ) {
+        this.dashboardAddress = pendingOwner;
+
+        return this.dashboardAddress;
+      }
+    }
+
+    if (isVaultConnected && !this.skipDashboardCheck) {
       throw this.bus.core.error({
         code: ERROR_CODE.NOT_SUPPORTED,
         message: 'Owner of vault is not dashboard contract',
@@ -753,16 +798,42 @@ export class LidoSDKVaultEntity extends BusModule {
     return dashboardContract.read.getRoleMembers([props.role]);
   }
 
+  /**
+   * Clone-proxy runtime code of the canonical Dashboard implementation.
+   * `DASHBOARD_IMPL` is immutable on a given factory, so it is safe to cache
+   * and to read at the latest block even when the caller pins `blockNumber`.
+   */
   @Logger('Utils:')
+  @Cache(30 * 60 * 1000, ['bus.core.chain.id'])
   @ErrorHandler()
-  private async isDashboard(address: Address) {
-    const dashboardCode = await this.bus.core.publicClient.getCode({ address });
+  private async getDashboardProxyCode(): Promise<string> {
     const vaultFactory = await this.bus.contracts.getContractVaultFactory();
     const implementation = await vaultFactory.read.DASHBOARD_IMPL();
-    const proxyCode =
+
+    return (
       PROXY_CODE_PAD_LEFT +
       implementation.slice(2).toLowerCase() +
-      PROXY_CODE_PAD_RIGHT;
+      PROXY_CODE_PAD_RIGHT
+    );
+  }
+
+  /**
+   * Whether `address` is a Dashboard, detected by comparing its deployed
+   * bytecode against the canonical Dashboard clone-proxy code.
+   */
+  @Logger('Utils:')
+  @ErrorHandler()
+  public async isDashboard(
+    address: Address,
+    props?: BlockNumberProps,
+  ): Promise<boolean> {
+    const [dashboardCode, proxyCode] = await Promise.all([
+      this.bus.core.publicClient.getCode({
+        address,
+        blockNumber: props?.blockNumber,
+      }),
+      this.getDashboardProxyCode(),
+    ]);
 
     return dashboardCode?.startsWith(proxyCode) || false;
   }
@@ -818,7 +889,7 @@ export class LidoSDKVaultEntity extends BusModule {
       lidoContract,
       // eslint-disable-next-line @typescript-eslint/await-thenable
     ] = await Promise.all([
-      this.getDashboardContract(),
+      this.getDashboardContract({ blockNumber }),
       this.getVaultContract(),
       this.bus.contracts.getContractVaultHub(),
       this.bus.contracts.getContractOperatorGrid(),
@@ -936,11 +1007,13 @@ export class LidoSDKVaultEntity extends BusModule {
       lidoContract.read.getMaxMintableExternalShares(),
     ]);
 
-    const supposedDashboardAddress =
-      vaultConnection.owner !== zeroAddress
-        ? vaultConnection.owner
-        : vaultOwner;
-    const isDashboard = await this.isDashboard(supposedDashboardAddress);
+    const supposedDashboardAddress = this.getSupposedDashboardAddress(
+      vaultConnection.owner,
+      vaultOwner,
+    );
+    const isDashboard = await this.isDashboard(supposedDashboardAddress, {
+      blockNumber,
+    });
 
     return {
       address: vaultAddress,

--- a/packages/sdk/src/stvault/vault-entity.ts
+++ b/packages/sdk/src/stvault/vault-entity.ts
@@ -31,7 +31,11 @@ import {
 import { Cache, ErrorHandler, Logger } from '../common/decorators/index.js';
 
 import { getVaultReport } from './utils/report.js';
-import { PROXY_CODE_PAD_LEFT, PROXY_CODE_PAD_RIGHT } from './consts/index.js';
+import {
+  PROXY_CODE_PAD_LEFT,
+  PROXY_CODE_PAD_RIGHT,
+  VAULT_ERROR_REASON,
+} from './consts/index.js';
 import {
   OverviewArgs,
   GetVaultOverviewDataProps,
@@ -139,6 +143,8 @@ export class LidoSDKVaultEntity extends BusModule {
   @Cache(30 * 60 * 1000, ['dashboardAddress'])
   @ErrorHandler()
   public async getDashboardAddress(props?: BlockNumberProps): Promise<Address> {
+    // an explicitly supplied address is trusted as-is: the only caller that
+    // passes one derives the pair from the `DashboardCreated` receipt event
     if (this.dashboardAddress) {
       return this.dashboardAddress;
     }
@@ -161,6 +167,10 @@ export class LidoSDKVaultEntity extends BusModule {
     );
 
     if (await this.isDashboard(supposedDashboardAddress, { blockNumber })) {
+      await this.assertDashboardBelongsToVault(
+        supposedDashboardAddress,
+        blockNumber,
+      );
       this.dashboardAddress = supposedDashboardAddress;
 
       return this.dashboardAddress;
@@ -178,6 +188,7 @@ export class LidoSDKVaultEntity extends BusModule {
         !isAddressEqual(pendingOwner, zeroAddress) &&
         (await this.isDashboard(pendingOwner, { blockNumber }))
       ) {
+        await this.assertDashboardBelongsToVault(pendingOwner, blockNumber);
         this.dashboardAddress = pendingOwner;
 
         return this.dashboardAddress;
@@ -187,6 +198,7 @@ export class LidoSDKVaultEntity extends BusModule {
     if (isVaultConnected && !this.skipDashboardCheck) {
       throw this.bus.core.error({
         code: ERROR_CODE.NOT_SUPPORTED,
+        reason: VAULT_ERROR_REASON.OWNER_NOT_DASHBOARD,
         message: 'Owner of vault is not dashboard contract',
       });
     }
@@ -836,6 +848,56 @@ export class LidoSDKVaultEntity extends BusModule {
     ]);
 
     return dashboardCode?.startsWith(proxyCode) || false;
+  }
+
+  /**
+   * Whether `dashboardAddress` is the Dashboard of *this* vault, i.e. its
+   * `stakingVault()` points back at the entity's vault.
+   *
+   * `isDashboard` only proves an address is a Dashboard-shaped clone proxy; it
+   * does not prove the Dashboard belongs to this vault. Both checks together
+   * are what make a resolved Dashboard address trustworthy.
+   */
+  @Logger('Utils:')
+  @ErrorHandler()
+  public async isDashboardBelongsToVault(
+    dashboardAddress: Address,
+    props?: BlockNumberProps,
+  ): Promise<boolean> {
+    const dashboard =
+      await this.bus.contracts.getContractVaultDashboard(dashboardAddress);
+    const stakingVaultAddress = await dashboard.read.stakingVault({
+      blockNumber: props?.blockNumber,
+    });
+
+    return isAddressEqual(stakingVaultAddress, this.vaultAddress);
+  }
+
+  /**
+   * Throws unless `dashboardAddress` is the Dashboard of this vault. No-op when
+   * the caller opted out via `skipDashboardCheck` — such consumers handle the
+   * mismatch themselves (see `isDashboardBelongsToVault`) and must not pay for
+   * the extra read here.
+   */
+  @Logger('Utils:')
+  @ErrorHandler()
+  private async assertDashboardBelongsToVault(
+    dashboardAddress: Address,
+    blockNumber?: bigint,
+  ): Promise<void> {
+    if (this.skipDashboardCheck) {
+      return;
+    }
+
+    if (await this.isDashboardBelongsToVault(dashboardAddress, { blockNumber })) {
+      return;
+    }
+
+    throw this.bus.core.error({
+      code: ERROR_CODE.NOT_SUPPORTED,
+      reason: VAULT_ERROR_REASON.DASHBOARD_NOT_BELONG_TO_VAULT,
+      message: `Dashboard ${dashboardAddress} does not belong to vault ${this.vaultAddress}`,
+    });
   }
 
   @Logger('Views:')


### PR DESCRIPTION
### Description

Moves Dashboard resolution and verification out of `staking-vault-widget` and into the SDK, where they belong.

**The underlying problem.** `LidoSDKVaultEntity.getDashboardAddress()` resolved the Dashboard as `vaultConnection.owner ?? vault.owner()`. That produced two defects of the same class — the SDK returned an address it called the vault's Dashboard without ever verifying it:

1. **The state after `voluntaryDisconnect()`.** The VaultHub takes ownership of the StakingVault and hands it back to the Dashboard with a 2-step transfer (Ownable2Step). In the window before `acceptOwnership()`, `vault.owner()` is the VaultHub and `vaultConnection.owner` is zero, so the SDK resolved the Dashboard address **to the VaultHub**, and every read through the entity targeted the wrong contract.
2. **`isDashboard()` does not prove ownership.** It only proves the address holds a clone proxy with the canonical Dashboard's bytecode — not that it is *this vault's* Dashboard. Point a vault's `owner` at a Dashboard belonging to a different vault and the SDK returns it happily. The back-link read (`Dashboard.stakingVault() == vaultAddress`) is the missing half of the proof.

The widget worked around both cases itself: writing to a private field behind `@ts-expect-error` with a `// TODO: move to SDK` marker, keeping its own copy of the bytecode check (`check-is-dashboard.ts`), and doing the `stakingVault()` cross-check inline.

**What changed** (`packages/sdk/src/`)

- **`getDashboardAddress(props?)`** — handles the pending-owner case itself. When the owner is not a Dashboard, the vault is disconnected, and the VaultHub owns it, it reads `vault.pendingOwner()` and uses that if it is a Dashboard. The read happens **only** in that branch, so connected vaults never pay for it. The three owner/connection reads are now batched into one `Promise.all` instead of three sequential awaits.
- **`isDashboard(address, props?)`** — was private, now public and block-aware. This is what lets the widget delete its copy of `check-is-dashboard.ts`. The proxy-code derivation moved into a private `getDashboardProxyCode()` under `@Cache(30 min)`, so `DASHBOARD_IMPL` is read once per instance instead of on every probe.
- **`isDashboardBelongsToVault(dashboardAddress, props?)`** — new public predicate: reads `Dashboard.stakingVault()` and compares it against the entity's vault address.
- **Linkage enforcement inside resolution**, gated by the existing `skipDashboardCheck` flag. The private `assertDashboardBelongsToVault` is called at the two points in `getDashboardAddress` where a Dashboard is confirmed — exactly the two cases the widget expresses as `isDashboard || isPendingOwnerDashboard`. It is deliberately **not** called on the final fallback return: there the address is already known not to be a Dashboard at all, so a linkage check is meaningless.
- **`SDKError.reason`** — new optional discriminator field for a specific failure condition, one level more granular than `code`. `code` and `ERROR_CODE` are untouched. The stVault module owns its own vocabulary: `VAULT_ERROR_REASON` plus the `VaultErrorReason` union in `stvault/consts/errors.ts`, following the `consts/roles.ts` pattern. **Both** conditions are tagged — `OWNER_NOT_DASHBOARD` (the pre-existing throw) and `DASHBOARD_NOT_BELONG_TO_VAULT` (the new one) — so a consumer can map them 1:1 onto its own messages and UI.
- **`getSupposedDashboardAddress(...)`** — the `vaultConnection.owner ?? vault.owner()` expression existed in two places with two different comparison styles (`isAddressEqual` in one, raw `!==` in the other). Extracted into a single private helper.
- **`getVaultOverviewData`** — the duplicated resolution is gone; its `isDashboard` probe and its `getDashboardContract()` call are now pinned to the method's own `blockNumber`. Previously they read at `latest` while the rest of the method read at a fixed block, so their data could straddle blocks.
- **`BlockNumberProps`** — new exported type in `stvault/types.ts`.
- **`docs/sdk/get-started/error-codes.md`** — restructured into `code` (categories) and `reason` (conditions), with the stVault reasons listed and a `switch` example.

**API impact: no breaking changes.** `getDashboardAddress` / `getDashboardContract` keep their return types and gain an optional argument. The public surface grows by `isDashboard`, `isDashboardBelongsToVault`, `SDKError.reason`, `VAULT_ERROR_REASON` / `VaultErrorReason`, and `BlockNumberProps` → semver-**minor**.

### Code review notes

**Why `reason` rather than a new `ERROR_CODE` member.** A dedicated error code was the first option considered, but `docs/sdk/get-started/error-codes.md` documents `ERROR_CODE` as **categories** ("NOT_SUPPORTED: behavior or feature though possible is not currently supported by SDK"), and `src` already throws `NOT_SUPPORTED` from 13 sites with 13 different messages — "one category, many conditions" is the SDK's established model across every module. A granular member would be the only condition-level entry among six category-level ones, would require editing the documented code list, and would break any consumer's exhaustive switch. `reason` gives the same discrimination, scales to the other 12 conditions without growing the enum, and is safe when ESM and CJS builds are mixed — unlike the alternative of `SDKError` subclasses plus `instanceof`. `code` stays `NOT_SUPPORTED` for both, so this is fully backward compatible.

**One change falls outside the stated scope.** `common/decorators/cache.ts` did `void result.then(onFulfilled)` with no rejection handler, so any `@Cache`-decorated method that rejects leaked an unhandled rejection from the derived promise. The new test for the `NOT_SUPPORTED` path is the first in the repo to hit that combination, and Vitest reported it as an error with a "might cause false positives" warning. The fix adds `() => undefined` as the second argument; only successful results were ever cached, so behaviour is unchanged. The file is shared by every module, so it is reasonable to split it out if you want this PR narrower.

**Why linkage enforcement sits under `skipDashboardCheck` rather than being unconditional.** The widget needs this check **as data, not as an exception**: its `DashboardNotBelongToVault` selects a dedicated modal via `instanceof`, sets `isRetryable: false`, and participates in react-query's `retry` predicate. So strict consumers get the check during resolution, while the widget — which passes `skipDashboardCheck: true` — calls the predicate itself and keeps its own error taxonomy. The flag thereby comes to mean "skip all Dashboard validation", which is coherent; no second flag was added. With `reason` in place the widget now also has a second option: drop its own checks and map SDK errors instead.

**The cost lands on the strict path, which is also the bulk path.** `bus.vaultFromAddress()` (`bus.ts:95`) does not pass `skipDashboardCheck`, so entities from `vaultViewer.fetchVaultsByOwnerEntities` / `fetchConnectedVaultEntities` (`vault-viewer.ts:65,76` — the only mass constructors, neither supplying a `dashboardAddress`) pay one extra read per vault. Entities are lazy: the reads happen on actual resolution, not on construction, so this is roughly +20% on an already 4–5-read resolution at point of use, not N reads up front. If that becomes a problem the fix is orthogonal to this PR: `vaultsDataBatch` returns `connection.owner` for a whole page in one call and is not wrapped by the SDK.

**An explicitly supplied `dashboardAddress` stays trusted** and still short-circuits every read, including the new check. The only production caller is `vault-factory.ts:223`, which derives the pair from the `DashboardCreated` receipt event and is therefore sound by construction. The assumption is recorded in a comment.

**A known wart left alone deliberately.** `this.dashboardAddress` is both the constructor-supplied override and the memoised result, so because of the short-circuit `blockNumber` only affects the **first** resolution on an instance. That is irrelevant for the widget (it constructs a fresh entity per query) and there is a comment in the code. It is pre-existing conflation, not something this PR sets out to fix.

**`isVaultDisconnected` semantics are unchanged.** In `getVaultOverviewData` it is still derived from "is the *current owner* a Dashboard", so a vault mid-voluntary-disconnect still reports `true`. Making the flag flip during the pending-owner window is a separate product decision with downstream consumers. The widget's `isVaultFullDisconnected` makes the same choice today.

### Testing notes

`packages/sdk/src/stvault/__tests__/vault-entity.test.ts` — 48 → 71 tests, in the file's existing pure-unit style (stub `Bus`, no anvil, no RPC). The stub is extended to cover `contracts.getContractVaultHub` / `getContractVault` / `getContractVaultFactory` / `getContractVaultDashboard`, `core.publicClient.getCode` and `core.error`; a `stakingVaultOf` map lets a Dashboard be pointed at a different vault.

Address resolution:

- owner is a Dashboard → returned immediately, `pendingOwner` is **not** read (guards against a regression that adds an RPC to the happy path)
- `vaultConnection.owner` non-zero → takes precedence over `vault.owner()`
- **VaultHub owns the vault, `pendingOwner` is a Dashboard, vault disconnected → returns `pendingOwner`** (the bug itself)
- pending owner is an EOA, not a Dashboard → falls through, no bogus address returned
- pending owner is `zeroAddress` → falls through
- vault still connected → `pendingOwner` never read, even when it would have matched
- connected + owner not a Dashboard + `skipDashboardCheck: false` → `NOT_SUPPORTED` with `reason: OWNER_NOT_DASHBOARD`
- `blockNumber` reaches `getCode` and every hub/vault read
- the result is memoised across calls
- a constructor-supplied `dashboardAddress` short-circuits every read

Linkage check — the negative cases matter most here, since they pin the cost and behaviour contract rather than just the happy path:

- predicate returns `true` on a match and `false` when it points at another vault
- strict mode: mismatch on the owner Dashboard → `DASHBOARD_NOT_BELONG_TO_VAULT`
- strict mode: mismatch on the pending-owner Dashboard → same
- **`skipDashboardCheck: true` resolves even a mismatched Dashboard, and `stakingVault` is never read** — proving the widget pays nothing extra and keeps its own error path
- the fallback branch (address is not a Dashboard at all) → `stakingVault` never read
- explicit `dashboardAddress` → `stakingVault` never read
- `blockNumber` reaches the `stakingVault` read
- **a dedicated test for the `reason` mechanism itself**: asserts both errors share the same `code` and that only `reason` distinguishes them. It fails if anyone tries to discriminate by `code` or drops `reason`.

Local runs: `yarn types` clean, `eslint --max-warnings 0` clean, `yarn build` produces all three outputs, and `dist/types` confirms the surface (`isDashboard`, `isDashboardBelongsToVault`, `SDKError.reason`, `VAULT_ERROR_REASON` public; `getSupposedDashboardAddress`, `getDashboardProxyCode`, `assertDashboardBelongsToVault` private).

**Not run locally:** the 26 integration test files need the `anvil` binary (Foundry) and a `.env` with an RPC URL and a private key, neither of which exists in my environment — they fail at fixture setup in `privateKeyToAccount(undefined)`. Verified via `git stash` that this is pre-existing: identical 26 failed / 5 passed before and after the change. Since the `cache.ts` fix touches shared code, **those suites are the ones that actually exercise it** — worth confirming in CI before merge.

**Manual verification not done**, needs a live RPC: (1) a vault that has called `voluntaryDisconnect()` but not `acceptOwnership()` — `getDashboardAddress()` should return the Dashboard, not the VaultHub; (2) a vault whose `owner` is another vault's Dashboard — a strict entity should throw with `reason: DASHBOARD_NOT_BELONG_TO_VAULT`, while one with `skipDashboardCheck: true` resolves and the predicate returns `false`. `playground/demo/stvault` is the place; note that `Bus.vaultFromAddress()` never passes `skipDashboardCheck`, so it exercises the strict path by default.

### Checklist:

- [x] Checked the changes locally. (types / lint / build / unit tests; integration suite not runnable locally — see Testing notes)
- [x] Created/updated unit tests.
- [x] Created/updated README.md. — updated `docs/sdk/get-started/error-codes.md` (`code` / `reason` sections). `docs/sdk/modules/stvault.md` does not yet mention the now-public `isDashboard` / `isDashboardBelongsToVault` — worth adding before release.

### Follow-up (separate PR, after a version release)

`staking-vault-widget` pins `@lidofinance/lido-ethereum-sdk` at `4.8.0` from the registry, so it cannot benefit until that is bumped. Once it is:

- delete `modules/vaults/utils/check-is-dashboard.ts` and its re-export, pointing both call sites at `vaultEntity.isDashboard(...)`;
- delete the `TODO: move to SDK` block and the `@ts-expect-error` in `use-base-vault-data.ts`;
- replace the inline `stakingVault()` cross-check with `vaultEntity.isDashboardBelongsToVault(dashboard.address, { blockNumber })`, still throwing `DashboardNotBelongToVault`; alternatively, drop `skipDashboardCheck: true` and map `error.reason` onto the modals;
- **move that check above the `settledGrowth` read** — `isPendingConnect` is currently derived from a Dashboard before it has been verified, so state can be derived from a contract that is then rejected;
- decide what to do about `get-vault-data-table.ts` and `fetch-vaults.ts`: they build Dashboard contracts and read `totalValue` / `liabilityShares` with no cross-check at all;
- re-check `isVaultFullDisconnected`, which currently ignores `isPendingOwnerDashboard`, and `use-disconnect-steps.ts`, where the `ACCEPT_OWNERSHIP` gate depends on the remapped `dashboard.address`.
